### PR TITLE
chore(resolver): resolve extensions via prefix

### DIFF
--- a/lib/resolver/nodeResolver.js
+++ b/lib/resolver/nodeResolver.js
@@ -43,7 +43,7 @@ function parseRuleName(ruleName) {
 
   if (slashIdx !== -1) {
     return {
-      pkg: ruleName.substring(0, slashIdx),
+      pkg: 'bpmnlint-plugin-' + ruleName.substring(0, slashIdx),
       ruleName: ruleName.substring(slashIdx + 1)
     };
   } else {
@@ -76,7 +76,7 @@ function parseConfigName(configName) {
   }
 
   return {
-    path: match[1],
+    path: 'bpmnlint-plugin-' + match[1],
     config: match[2]
   };
 }

--- a/test/spec/resolver/nodeResolverSpec.js
+++ b/test/spec/resolver/nodeResolverSpec.js
@@ -31,7 +31,7 @@ describe('nodeResolver', function() {
       const { path } = nodeResolver.parseRuleName('foo/label-required');
 
       // then
-      expect(path).to.eql('foo/rules/label-required');
+      expect(path).to.eql('bpmnlint-plugin-foo/rules/label-required');
     });
 
   });
@@ -66,7 +66,7 @@ describe('nodeResolver', function() {
       } = nodeResolver.parseConfigName('plugin:foo/bar');
 
       // then
-      expect(path).to.eql('foo');
+      expect(path).to.eql('bpmnlint-plugin-foo');
       expect(config).to.eql('bar');
     });
 


### PR DESCRIPTION
It is an interesting question whether or not we should force a common prefix for all `bpmnlint` related extension libraries. This PR adds the functionality by prefixing resolved rules and configurations with a `bpmnlint-plugin-` prefix.