### PR TITLE
Skip resolving of disabled rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmnlint](https://github.com/bpmn-io/bpmnlint) are docum
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: don't resolve disabled rules ([`6c45f3f9`](https://github.com/bpmn-io/bpmnlint/commit/6c45f3f952a412dda05deb5c57861a1c76af23bb))
+
 ## 3.3.0
 
 * `FEAT`: do not expose disabled rules when bundling `.bpmnlintrc`

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1,7 +1,7 @@
 const testRule = require('./test-rule');
 const utils = require('./utils');
 
-const flagMap = {
+const categoryMap = {
   0: 'off',
   1: 'warn',
   2: 'error'
@@ -32,19 +32,13 @@ module.exports = Linter;
 /**
  * Applies a rule on the moddleRoot and adds reports to the finalReport
  *
- * @param {ModdleElement} options.moddleRoot
- * @param {String} options.ruleFlag
- * @param {Rule} options.rule
- * @param {Object} options.ruleConfig
+ * @param {ModdleElement} moddleRoot
+ * @param {Rule} rule
+ * @param {Object} ruleConfig
  *
  * @return {Array<ValidationErrors>} lint results
  */
-Linter.prototype.applyRule = function applyRule({ moddleRoot, ruleFlag, rule, ruleConfig }) {
-
-  if (ruleFlag === 'off') {
-    return [];
-  }
-
+Linter.prototype.applyRule = function applyRule(moddleRoot, rule, ruleConfig) {
   return testRule({ moddleRoot, rule, ruleConfig });
 };
 
@@ -106,25 +100,47 @@ Linter.prototype.resolveConfig = function(name) {
 /**
  * Take a linter config and return list of resolved rules.
  *
- * @param {Object} rulesConfig
+ * @param {Object} config
  *
  * @return {Array<RuleDefinition>}
  */
 Linter.prototype.resolveRules = function(config) {
 
   return this.resolveConfiguredRules(config).then((rulesConfig) => {
-    return Promise.all(
-      Object.entries(rulesConfig).map(([ name, value ]) => {
 
-        return this.resolveRule(name).then(function(rule) {
-          return {
-            value,
-            name,
-            rule
-          };
-        });
-      })
-    );
+    // parse rule values
+    const parsedRules = Object.entries(rulesConfig).map(([ name, value ]) => {
+      const {
+        category,
+        config
+      } = this.parseRuleValue(value);
+
+      return {
+        name,
+        category,
+        config
+      };
+    });
+
+    // filter only for enabled rules
+    const enabledRules = parsedRules.filter(definition => definition.category !== 'off');
+
+    // load enabled rules
+    const loaders = enabledRules.map((definition) => {
+
+      const {
+        name
+      } = definition;
+
+      return this.resolveRule(name).then(function(rule) {
+        return {
+          ...definition,
+          rule
+        };
+      });
+    });
+
+    return Promise.all(loaders);
   });
 };
 
@@ -180,14 +196,16 @@ Linter.prototype.lint = function(moddleRoot, config) {
 
     const finalReport = {};
 
-    ruleDefinitions.forEach(({ rule, name, value }) => {
+    ruleDefinitions.forEach((ruleDefinition) => {
 
       const {
-        ruleFlag,
-        ruleConfig
-      } = this.parseRuleValue(value);
+        rule,
+        name,
+        config,
+        category
+      } = ruleDefinition;
 
-      const reports = this.applyRule({ moddleRoot, ruleFlag, rule, ruleConfig });
+      const reports = this.applyRule(moddleRoot, rule, config);
 
       if (reports.length === 0) {
         return;
@@ -196,7 +214,7 @@ Linter.prototype.lint = function(moddleRoot, config) {
       const categorizedReports = reports.map(function(report) {
         return {
           ...report,
-          category: ruleFlag
+          category
         };
       });
 
@@ -210,28 +228,28 @@ Linter.prototype.lint = function(moddleRoot, config) {
 
 Linter.prototype.parseRuleValue = function(value) {
 
-  let ruleFlag;
-  let ruleConfig;
+  let category;
+  let config;
 
   if (Array.isArray(value)) {
-    ruleFlag = value[0];
-    ruleConfig = value[1];
+    category = value[0];
+    config = value[1];
   } else {
-    ruleFlag = value;
-    ruleConfig = {};
+    category = value;
+    config = {};
   }
 
   // normalize rule flag to <error> and <warn> which
   // may be upper case or a number at this point
-  if (typeof ruleFlag === 'string') {
-    ruleFlag = ruleFlag.toLowerCase();
+  if (typeof category === 'string') {
+    category = category.toLowerCase();
   }
 
-  ruleFlag = flagMap[ruleFlag] || ruleFlag;
+  category = categoryMap[category] || category;
 
   return {
-    ruleConfig,
-    ruleFlag
+    config,
+    category
   };
 };
 

--- a/lib/support/compile-config.js
+++ b/lib/support/compile-config.js
@@ -22,9 +22,9 @@ async function compileConfig(config) {
   const enabledRules = Object.keys(resolvedRules).reduce(function(enabledRules, key) {
     const value = resolvedRules[key];
 
-    const { ruleFlag } = linter.parseRuleValue(value);
+    const { category } = linter.parseRuleValue(value);
 
-    if (ruleFlag !== 'off') {
+    if (category !== 'off') {
       enabledRules[key] = value;
     }
 


### PR DESCRIPTION
Ensure we only resolve rules that are actually enabled.

_This is a performance enhancement and matches the behavior seen in, e.g. `eslint`._