### PR TITLE
chore(ci): add macos and windows test environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ node_js:
   - 10
   - 8
 
+os:
+  - linux
+  - osx
+  - windows
+
 script:
   - npm run all
   - npx codecov


### PR DESCRIPTION
Testing the library on Windows and MacOS, too.

Ref: https://github.com/bpmn-io/bpmnlint/pull/47