### PR TITLE
fix(rules/no-disconnected): exclude compensation task and boundary

### DIFF
--- a/rules/no-disconnected.js
+++ b/rules/no-disconnected.js
@@ -1,5 +1,6 @@
 const {
-  isAny
+  isAny,
+  is
 } = require('bpmnlint-utils');
 
 
@@ -21,6 +22,13 @@ module.exports = function() {
       return;
     }
 
+    // compensation activity and boundary events are
+    // linked visually via associations. If these associations
+    // exist we are fine, too
+    if (isCompensationLinked(node)) {
+      return;
+    }
+
     const incoming = node.incoming || [];
     const outgoing = node.outgoing || [];
 
@@ -32,5 +40,34 @@ module.exports = function() {
   return {
     check
   };
-
 };
+
+
+// helpers /////////////////
+
+function isCompensationBoundary(node) {
+
+  var eventDefinitions = node.eventDefinitions;
+
+  if (!is(node, 'bpmn:BoundaryEvent')) {
+    return false;
+  }
+
+  if (!eventDefinitions || eventDefinitions.length !== 1) {
+    return false;
+  }
+
+  return is(eventDefinitions[0], 'bpmn:CompensateEventDefinition');
+}
+
+function isCompensationActivity(node) {
+  return node.isForCompensation;
+}
+
+function isCompensationLinked(node) {
+  var source = isCompensationBoundary(node);
+  var target = isCompensationActivity(node);
+
+  // TODO(nikku): check, whether compensation association exists
+  return source || target;
+}

--- a/test/rules/no-disconnected.js
+++ b/test/rules/no-disconnected.js
@@ -17,6 +17,9 @@ RuleTester.verify('no-disconnected', rule, {
     },
     {
       moddleElement: readModdle(__dirname + '/no-disconnected/valid-event-subprocess.bpmn')
+    },
+    {
+      moddleElement: readModdle(__dirname + '/no-disconnected/valid-compensation.bpmn')
     }
   ],
   invalid: [

--- a/test/rules/no-disconnected/valid-compensation.bpmn
+++ b/test/rules/no-disconnected/valid-compensation.bpmn
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_112pboa" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.6.0">
+  <bpmn:process id="Process_1ey596u" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_04ixavt</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_02vrk4f">
+      <bpmn:incoming>Flow_04ixavt</bpmn:incoming>
+      <bpmn:outgoing>Flow_0xkonay</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_04ixavt" sourceRef="StartEvent_1" targetRef="Activity_02vrk4f" />
+    <bpmn:sequenceFlow id="Flow_0xkonay" sourceRef="Activity_02vrk4f" targetRef="Event_09gv6eq" />
+    <bpmn:boundaryEvent id="Event_05sly58" attachedToRef="Activity_02vrk4f">
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_02lxnvn" />
+    </bpmn:boundaryEvent>
+    <bpmn:task id="Activity_0qb6zkz" isForCompensation="true" />
+    <bpmn:endEvent id="Event_09gv6eq">
+      <bpmn:incoming>Flow_0xkonay</bpmn:incoming>
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_0o59e1w" />
+    </bpmn:endEvent>
+    <bpmn:association id="Association_0bat8sy" associationDirection="One" sourceRef="Event_05sly58" targetRef="Activity_0qb6zkz" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1ey596u">
+      <bpmndi:BPMNEdge id="Flow_0xkonay_di" bpmnElement="Flow_0xkonay">
+        <di:waypoint x="340" y="120" />
+        <di:waypoint x="392" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04ixavt_di" bpmnElement="Flow_04ixavt">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="240" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02vrk4f_di" bpmnElement="Activity_02vrk4f">
+        <dc:Bounds x="240" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0qb6zkz_di" bpmnElement="Activity_0qb6zkz">
+        <dc:Bounds x="360" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0j26sag_di" bpmnElement="Event_09gv6eq">
+        <dc:Bounds x="392" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1u3pwah_di" bpmnElement="Event_05sly58">
+        <dc:Bounds x="272" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0bat8sy_di" bpmnElement="Association_0bat8sy">
+        <di:waypoint x="290" y="178" />
+        <di:waypoint x="290" y="240" />
+        <di:waypoint x="360" y="240" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
These elements must be checked separately for a association.