### PR TITLE
feat: resolve local package by name

### DIFF
--- a/lib/resolver/node-resolver.js
+++ b/lib/resolver/node-resolver.js
@@ -9,12 +9,22 @@ function NodeResolver(options) {
   this.require = options && options.require || createScopedRequire(process.cwd());
 
   this.requireLocal = options && options.requireLocal || require;
+
+  try {
+    this.pkg = this.require('./package.json').name;
+  } catch (err) {
+    this.pkg = '__unknown';
+  }
 }
 
 module.exports = NodeResolver;
 
 
 NodeResolver.prototype.resolveRule = function(pkg, ruleName) {
+
+  const originalPkg = pkg;
+
+  pkg = this.normalizePkg(pkg);
 
   try {
     if (pkg === 'bpmnlint') {
@@ -23,11 +33,15 @@ NodeResolver.prototype.resolveRule = function(pkg, ruleName) {
       return this.require(`${pkg}/rules/${ruleName}`);
     }
   } catch (err) {
-    throw new Error('Cannot resolve rule <' + ruleName + '> from <' + pkg + '>');
+    throw new Error('Cannot resolve rule <' + ruleName + '> from <' + originalPkg + '>');
   }
 };
 
 NodeResolver.prototype.resolveConfig = function(pkg, configName) {
+
+  const originalPkg = pkg;
+
+  pkg = this.normalizePkg(pkg);
 
   // resolve config via $PKG/config/$NAME
   try {
@@ -53,10 +67,17 @@ NodeResolver.prototype.resolveConfig = function(pkg, configName) {
   }
 
   throw new Error(
-    'Cannot resolve config <' + configName + '> from <' + pkg + '>'
+    'Cannot resolve config <' + configName + '> from <' + originalPkg + '>'
   );
 };
 
+NodeResolver.prototype.normalizePkg = function(pkg) {
+  if (pkg !== 'bpmnlint' && pkg === this.pkg) {
+    pkg = '.';
+  }
+
+  return pkg;
+};
 
 // helpers ////////////////////
 

--- a/lib/support/compile-config.js
+++ b/lib/support/compile-config.js
@@ -7,13 +7,15 @@ const NodeResolver = require('../resolver/node-resolver');
  * a { config, resolver } bundle, resolving all enabled rules.
  *
  * @param  {Object} config the parsed bpmnlint configuration
- *
+ * @param  {NodeResolver} [resolver]
  * @return {Promise<String>} the configuration compiled to a JS file
  */
-async function compileConfig(config) {
+async function compileConfig(config, resolver) {
+
+  resolver = resolver || new NodeResolver();
 
   const linter = new Linter({
-    resolver: new NodeResolver()
+    resolver
   });
 
   const resolvedRules = await linter.resolveConfiguredRules(config);
@@ -86,7 +88,7 @@ export default bundle;
     } = linter.parseRuleName(key);
 
     return `
-import rule_${idx} from '${pkg}/rules/${ruleName}';
+import rule_${idx} from '${resolver.normalizePkg(pkg)}/rules/${ruleName}';
 cache['${pkg}/${ruleName}'] = rule_${idx};`;
   }).join('\n');
 

--- a/test/spec/resolver/node-resolver-spec.js
+++ b/test/spec/resolver/node-resolver-spec.js
@@ -11,7 +11,14 @@ describe('resolver/node-resolver', function() {
 
     const resolver = createResolver(function(path) {
 
-      if (path === 'baz/rules/non-existing') {
+      // mimic local package look-up
+      if (path === './package.json') {
+        return {
+          name: 'bpmnlint-plugin-local'
+        };
+      }
+
+      if (path.includes('rules/non-existing')) {
         throw new Error('not found');
       }
 
@@ -65,11 +72,23 @@ describe('resolver/node-resolver', function() {
     it('should resolve external', async function() {
 
       // when
-      const resolvedRule = await resolver.resolveRule('foo', 'label-required');
+      const resolvedRule = await resolver.resolveRule('bpmnlint-plugin-foo', 'label-required');
 
       // then
       expect(resolvedRule).to.eql({
-        path: 'foo/rules/label-required'
+        path: 'bpmnlint-plugin-foo/rules/label-required'
+      });
+    });
+
+
+    it('should resolve local package', async function() {
+
+      // when
+      const resolvedRule = await resolver.resolveRule('bpmnlint-plugin-local', 'label-required');
+
+      // then
+      expect(resolvedRule).to.eql({
+        path: './rules/label-required'
       });
     });
 
@@ -80,11 +99,31 @@ describe('resolver/node-resolver', function() {
 
       // when
       try {
-        await resolver.resolveRule('baz', 'non-existing');
+        await resolver.resolveRule('bpmnlint-plugin-baz', 'non-existing');
       } catch (e) {
 
         // then
-        expect(e.message).to.eql('Cannot resolve rule <non-existing> from <baz>');
+        expect(e.message).to.eql('Cannot resolve rule <non-existing> from <bpmnlint-plugin-baz>');
+
+        err = e;
+      }
+
+      // verify
+      expect(err).to.exist;
+    });
+
+
+    it('should fail to resolve local', async function() {
+
+      let err;
+
+      // when
+      try {
+        await resolver.resolveRule('bpmnlint-plugin-local', 'non-existing');
+      } catch (e) {
+
+        // then
+        expect(e.message).to.eql('Cannot resolve rule <non-existing> from <bpmnlint-plugin-local>');
 
         err = e;
       }
@@ -100,27 +139,29 @@ describe('resolver/node-resolver', function() {
 
     const resolver = createResolver(function(path) {
 
+      // mimic local package look-up
+      if (path === './package.json') {
+        return {
+          path,
+          name: 'bpmnlint-plugin-local'
+        };
+      }
+
       // mimic $PKG/config/$NAME resolution
-      if (path === 'bpmnlint-plugin-foo/config/bar') {
+      if (path.includes('config/bar')) {
         return {
           path,
           bar: true
         };
       }
 
-      if (path.startsWith('bpmnlint-plugin-foo/config')) {
+      // mimic embedded config not found via $PKG/config/$NAME
+      if (path.includes('config/embedded')) {
         throw new Error('not found');
       }
 
-
-      if (path.indexOf('config') !== -1) {
-        return {
-          path
-        };
-      }
-
       // mimic $PKG.configs[$NAME] resolution
-      if (path === 'bpmnlint-plugin-foo') {
+      if (path === 'bpmnlint-plugin-foo' || path === '.') {
         return {
           configs: {
             embedded: {
@@ -224,6 +265,36 @@ describe('resolver/node-resolver', function() {
     });
 
 
+    describe('should resolve local package', function() {
+
+      it('via ./config/$NAME', async function() {
+
+        // when
+        const resolvedConfig = await resolver.resolveConfig('bpmnlint-plugin-local', 'bar');
+
+        // then
+        expect(resolvedConfig).to.eql({
+          path: './config/bar',
+          bar: true
+        });
+      });
+
+
+      it('via .configs[$NAME]', async function() {
+
+        // when
+        const resolvedConfig = await resolver.resolveConfig('bpmnlint-plugin-local', 'embedded');
+
+        // then
+        expect(resolvedConfig).to.eql({
+          path: '.',
+          embedded: true
+        });
+      });
+
+    });
+
+
     it('should fail to resolve external', async function() {
 
       let err;
@@ -234,6 +305,26 @@ describe('resolver/node-resolver', function() {
       } catch (e) {
         expect(e.message).to.eql(
           'Cannot resolve config <non-existing> from <bpmnlint-plugin-foo>'
+        );
+
+        err = e;
+      }
+
+      // verify
+      expect(err).to.exist;
+    });
+
+
+    it('should fail to resolve local', async function() {
+
+      let err;
+
+      // when
+      try {
+        await resolver.resolveConfig('bpmnlint-plugin-local', 'non-existing');
+      } catch (e) {
+        expect(e.message).to.eql(
+          'Cannot resolve config <non-existing> from <bpmnlint-plugin-local>'
         );
 
         err = e;

--- a/test/spec/support/compile-config-spec.js
+++ b/test/spec/support/compile-config-spec.js
@@ -1,5 +1,7 @@
 const { expect } = require('chai');
 
+import NodeResolver from '../../../lib/resolver/node-resolver';
+
 import compileConfig from '../../../lib/support/compile-config';
 
 
@@ -42,6 +44,42 @@ describe('support/compile-config', function() {
     // then
     expect(code).to.contain('import rule_0 from \'@foo/bpmnlint-plugin-bar/rules/rule\'');
     expect(code).to.contain('cache[\'@foo/bpmnlint-plugin-bar/rule\'] = rule_0');
+  });
+
+
+  it('should import local', async function() {
+
+    // given
+    const resolver = new NodeResolver({
+      require: function(path) {
+
+        if (path === './package.json') {
+          return {
+            name: 'bpmnlint-plugin-local'
+          };
+        }
+
+        if (path === './config/recommended') {
+          return {
+            rules: {
+              'foo': 'error'
+            }
+          };
+        }
+
+        throw new Error('not found');
+      }
+    });
+
+
+    // when
+    const code = await compileConfig({
+      extends: 'plugin:local/recommended'
+    }, resolver);
+
+    // then
+    expect(code).to.contain('import rule_0 from \'./rules/foo\'');
+    expect(code).to.contain('cache[\'bpmnlint-plugin-local/foo\'] = rule_0');
   });
 
 


### PR DESCRIPTION
This PR ensures that rules implemented locally are also resolved locally within the package.

To do that we check for a local `package.json`. If it exists we use the package name to normalize required configs and rules.

Adjustment must be done both when resolving rules as well as when compiling the linter configuration.

----

Given this enhancements local rules can be safely referenced by name (of the package):

```
bpmnlint-plugin-foobar
-> index.js
-> .bpmnlintrc = { "extends": "plugins:foobar/recommended" }
```

---

How to try out:

```sh
git clone https://github.com/bpmn-io/bpmnlint-plugin-example
cd bpmnlint-plugin-example
echo '{ "extends": "plugin:example/recommended" }' > .bpmnlintrc
npx bpmnlint@bpmn-io/bpmnlint#local-package-resolution some-bpmn-diagram.bpmn
```