### PR TITLE
feat: support `--version` switch

### DIFF
--- a/bin/bpmnlint.js
+++ b/bin/bpmnlint.js
@@ -146,6 +146,12 @@ function errorAndExit(...args) {
   process.exit(1);
 }
 
+function showVersionAndExit() {
+  console.log(require('../package.json').version);
+
+  process.exit(0);
+}
+
 function infoAndExit(...args) {
   console.log(...args);
 
@@ -314,6 +320,7 @@ async function run() {
   const {
     help,
     init,
+    version,
     config: configOverridePath,
     _: files
   } = mri(process.argv.slice(2), {
@@ -322,6 +329,10 @@ async function run() {
       c: 'config'
     }
   });
+
+  if (version) {
+    return showVersionAndExit();
+  }
 
   if (help) {
     return infoAndExit(HELP_STRING);

--- a/test/integration/cli-spec.js
+++ b/test/integration/cli-spec.js
@@ -138,6 +138,16 @@ describe('cli', function() {
       }
     });
 
+
+    test({
+      cmd: [ 'bpmnlint', '--version' ],
+      expct: {
+        code: 0,
+        stderr: EMPTY,
+        stdout: require('../../package.json').version
+      }
+    });
+
   });
 
 


### PR DESCRIPTION
Ensures the cli reports the bpmnlint version if asked to do so via
the standard `--version` switch.