### PR TITLE
Ensure `no-bpmndi` does not blow up on missing `LaneSet#lanes`

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -33,9 +33,9 @@ function verify(ruleName, rule, testCases) {
 
     describe('should lint valid', function() {
 
-      testCases.valid.forEach(({ moddleElement }, idx) => (
+      testCases.valid.forEach(({ moddleElement, it: _it }, idx) => (
 
-        it(`test case #${idx + 1}`, function() {
+        (_it || it)(`test case #${idx + 1}`, function() {
           return (
             Promise.resolve(moddleElement)
               .then(moddleRoot => {
@@ -54,9 +54,9 @@ function verify(ruleName, rule, testCases) {
 
     describe('should lint invalid', function() {
 
-      testCases.invalid.forEach(({ moddleElement, report }, idx) => (
+      testCases.invalid.forEach(({ moddleElement, report, it: _it }, idx) => (
 
-        it(`test case #${idx}`, function() {
+        (_it || it)(`test case #${idx}`, function() {
 
           if (!Array.isArray(report)) {
             report = [

--- a/rules/no-bpmndi.js
+++ b/rules/no-bpmndi.js
@@ -54,6 +54,9 @@ module.exports = function() {
 function getAllBpmnElements(rootElements) {
   return flatten(rootElements.map((rootElement) => {
 
+    const laneSet =
+      rootElement.laneSets && rootElement.laneSets[0] || rootElement.childLaneSet;
+
     // Include
     // * flowElements (e.g., tasks, sequenceFlows),
     // * nested flowElements,
@@ -68,10 +71,8 @@ function getAllBpmnElements(rootElements) {
       (rootElement.flowElements && getAllBpmnElements(rootElement.flowElements.filter(hasFlowElements))) || [],
       rootElement.participants || [],
       rootElement.artifacts || [],
-      (rootElement.laneSets && rootElement.laneSets[0].lanes) || [],
-      (rootElement.laneSets && getAllBpmnElements(rootElement.laneSets[0].lanes.filter(hasChildLaneSet))) || [],
-      (rootElement.childLaneSet && rootElement.childLaneSet.lanes) || [],
-      (rootElement.childLaneSet && getAllBpmnElements(rootElement.childLaneSet.lanes.filter(hasChildLaneSet))) || []
+      laneSet && laneSet.lanes || [],
+      laneSet && laneSet.lanes && getAllBpmnElements(laneSet.lanes.filter(hasChildLaneSet)) || []
     ));
 
     if (elements.length > 0) {

--- a/test/rules/no-bpmndi.js
+++ b/test/rules/no-bpmndi.js
@@ -44,6 +44,9 @@ RuleTester.verify('no-bpmndi', rule, {
     },
     {
       moddleElement: readModdle(__dirname + '/no-bpmndi/valid-empty.bpmn')
+    },
+    {
+      moddleElement: readModdle(__dirname + '/no-bpmndi/valid-no-lanes.bpmn')
     }
   ],
   invalid: [
@@ -52,7 +55,6 @@ RuleTester.verify('no-bpmndi', rule, {
       report: {
         id: 'boundaryEvent',
         message: 'Element is missing bpmndi'
-
       }
     },
     {

--- a/test/rules/no-bpmndi/valid-no-lanes.bpmn
+++ b/test/rules/no-bpmndi/valid-no-lanes.bpmn
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="sid-38422fae-e03e-43a3-bef4-bd33b32041b2" targetNamespace="http://bpmn.io/bpmn" exporter="bpmn-js (https://demo.bpmn.io)" exporterVersion="8.8.2">
+  <process id="Process_1" isExecutable="false">
+    <bpmn:laneSet id="LaneSet_1hpv2hv" />
+    <startEvent id="StartEvent_1y45yut" name="hunger noticed" />
+  </process>
+  <bpmndi:BPMNDiagram id="BpmnDiagram_1">
+    <bpmndi:BPMNPlane id="BpmnPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="StartEvent_1y45yut_di" bpmnElement="StartEvent_1y45yut">
+        <omgdc:Bounds x="152" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="134" y="145" width="73" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>


### PR DESCRIPTION
Closes https://github.com/bpmn-io/bpmnlint/issues/63.