### PR TITLE
feat: add optional name to tests through RuleTester.verify

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -33,9 +33,9 @@ function verify(ruleName, rule, testCases) {
 
     describe('should lint valid', function() {
 
-      testCases.valid.forEach(({ moddleElement, it: _it }, idx) => (
+      testCases.valid.forEach(({ moddleElement, name, it: _it }, idx) => (
 
-        (_it || it)(`test case #${idx + 1}`, function() {
+        (_it || it)(getTitle(idx, name), function() {
           return (
             Promise.resolve(moddleElement)
               .then(moddleRoot => {
@@ -54,9 +54,9 @@ function verify(ruleName, rule, testCases) {
 
     describe('should lint invalid', function() {
 
-      testCases.invalid.forEach(({ moddleElement, report, it: _it }, idx) => (
+      testCases.invalid.forEach(({ moddleElement, name, report, it: _it }, idx) => (
 
-        (_it || it)(`test case #${idx}`, function() {
+        (_it || it)(getTitle(idx, name), function() {
 
           if (!Array.isArray(report)) {
             report = [
@@ -94,7 +94,11 @@ function verify(ruleName, rule, testCases) {
 
 }
 
+function getTitle(idx, name) {
+  return `test case #${ idx + 1 }${ name ? ` ${ name }`: '' }`;
+}
 
 module.exports = {
-  verify
+  verify,
+  getTitle
 };

--- a/test/rules/conditional-flows.js
+++ b/test/rules/conditional-flows.js
@@ -10,20 +10,25 @@ import {
 RuleTester.verify('conditional-flows', rule, {
   valid: [
     {
+      name: 'split',
       moddleElement: readModdle(__dirname + '/conditional-flows/valid-split.bpmn')
     },
     {
+      name: 'split after task',
       moddleElement: readModdle(__dirname + '/conditional-flows/valid-split-after-task.bpmn')
     },
     {
+      name: 'conditional fork',
       moddleElement: readModdle(__dirname + '/conditional-flows/valid-conditional-fork.bpmn')
     },
     {
+      name: 'no condition after merge',
       moddleElement: readModdle(__dirname + '/conditional-flows/valid-no-condition-after-merge.bpmn')
     }
   ],
   invalid: [
     {
+      name: 'fork after exclusive gateway',
       moddleElement: readModdle(__dirname + '/conditional-flows/invalid-fork-after-exclusive-gateway.bpmn'),
       report: {
         id: 'Flow_2',
@@ -31,6 +36,7 @@ RuleTester.verify('conditional-flows', rule, {
       }
     },
     {
+      name: 'fork after exclusive gateway default',
       moddleElement: readModdle(__dirname + '/conditional-flows/invalid-fork-after-exclusive-gateway-default.bpmn'),
       report: {
         id: 'Flow_1',
@@ -38,6 +44,7 @@ RuleTester.verify('conditional-flows', rule, {
       }
     },
     {
+      name: 'fork after task',
       moddleElement: readModdle(__dirname + '/conditional-flows/invalid-fork-after-task.bpmn'),
       report: {
         id: 'Flow_1',
@@ -45,6 +52,7 @@ RuleTester.verify('conditional-flows', rule, {
       }
     },
     {
+      name: 'fork after task default',
       moddleElement: readModdle(__dirname + '/conditional-flows/invalid-fork-after-task-default.bpmn'),
       report: {
         id: 'Flow_1',

--- a/test/spec/testers/rule-tester-spec.js
+++ b/test/spec/testers/rule-tester-spec.js
@@ -1,0 +1,31 @@
+import { getTitle } from '../../../lib/testers/rule-tester';
+
+import { expect } from '../../helper';
+
+
+describe('rule-tester', function() {
+
+  describe('#getTitle', function() {
+
+    it('it should get name (index)', function() {
+
+      // when
+      const title = getTitle(1);
+
+      // then
+      expect(title).to.equal('test case #2');
+    });
+
+
+    it('it should get name (index and name)', function() {
+
+      // when
+      const title = getTitle(1, 'foo');
+
+      // then
+      expect(title).to.equal('test case #2 foo');
+    });
+
+  });
+
+});


### PR DESCRIPTION
Improves console output from

```sh
rules/camunda-cloud-1-0-integration
    should lint valid
      √ test case #1
      √ test case #2
      √ test case #3
```

to

```sh
rules/camunda-cloud-1-0-integration
    should lint valid
      √ test case #1 bpmndi elements
      √ test case #2 parse collaborations
      √ test case #3 conditional sequence flows
```

---

Closes #67