### PR TITLE
Provide Additional Information when Calling `Reporter#report`

### DIFF
--- a/lib/test-rule.js
+++ b/lib/test-rule.js
@@ -1,5 +1,11 @@
 const traverse = require('./traverse');
 
+const {
+  isArray,
+  isObject
+} = require('min-dash');
+
+
 class Reporter {
   constructor({ moddleRoot, rule }) {
     this.rule = rule;
@@ -8,16 +14,39 @@ class Reporter {
     this.report = this.report.bind(this);
   }
 
+  /**
+   * @param {string} id
+   * @param {string} message
+   * @param {string[]|Object} path
+   *
+   * @example
+   *
+   * Reporter.report('foo', 'Foo error', [ 'foo', 'bar', 'baz' ]);
+   *
+   * @example
+   *
+   * Reporter.report('foo', 'Foo error', {
+   *  path: [ 'foo', 'bar', 'baz' ],
+   *  foo: 'foo'
+   * });
+   */
   report(id, message, path) {
     let report = {
       id,
       message
     };
 
-    if (path) {
+    if (path && isArray(path)) {
       report = {
         ...report,
         path
+      };
+    }
+
+    if (path && isObject(path)) {
+      report = {
+        ...report,
+        ...path
       };
     }
 

--- a/test/integration/cli-spec.js
+++ b/test/integration/cli-spec.js
@@ -235,6 +235,7 @@ describe('cli', function() {
     });
   });
 
+
   describe('should handle glob star patterns', function() {
     test({
       cmd: [ 'bpmnlint', '*.bpmn'],
@@ -298,6 +299,7 @@ describe('cli', function() {
       }
     });
   });
+
 });
 
 // helper /////////////////////////////

--- a/test/spec/test-rule-spec.js
+++ b/test/spec/test-rule-spec.js
@@ -55,6 +55,27 @@ describe('test-rule', function() {
   });
 
 
+  it('should return check function reported messages (id, message, { path })', () => {
+
+    // given
+    const expectedMessages = [
+      {
+        id: 'Collaboration_0wzd2dx',
+        message: 'Collaboration detected',
+        path: [ 'rootElements', 0 ],
+        foo: 'foo'
+      }
+    ];
+    const messages = testRule({
+      moddleRoot,
+      rule: createRule(fakeCheckRuleWithObject)
+    });
+
+    // then
+    expect(messages).to.eql(expectedMessages);
+  });
+
+
   it('should return { enter, leave } hook reported messages', () => {
 
     // given
@@ -109,6 +130,19 @@ function fakeCheckRuleWithPath() {
   function check(node, reporter) {
     if (is(node, 'Collaboration')) {
       reporter.report(node.id, 'Collaboration detected', [ 'rootElements', 0 ]);
+    }
+  }
+
+  return { check };
+}
+
+function fakeCheckRuleWithObject() {
+  function check(node, reporter) {
+    if (is(node, 'Collaboration')) {
+      reporter.report(node.id, 'Collaboration detected', {
+        path: [ 'rootElements', 0 ],
+        foo: 'foo'
+      });
     }
   }
 


### PR DESCRIPTION
Provide additional information by providing object as third argument.

### Example

```js
Reporter.report('foo', 'Foo error', [ 'foo', 'bar', 'baz' ]);

Reporter.report('foo', 'Foo error', {
  path: [ 'foo', 'bar', 'baz' ],
  foo: 'foo'
});
```