### PR TITLE
feat(rule-tester): fuzzy test for equality of moddle elements

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -11,7 +11,7 @@ function createResolver(rule) {
 }
 
 function expectEqual(a, b) {
-  assert.deepStrictEqual(a, b);
+  assert.deepStrictEqual(JSON.stringify(a, replacer, 2), JSON.stringify(b, replacer, 2));
 }
 
 
@@ -99,6 +99,37 @@ function getTitle(idx, name) {
 }
 
 module.exports = {
+  expectEqual,
   verify,
   getTitle
 };
+
+function replacer(_, value) {
+  if (!value) {
+    return;
+  }
+
+  const { $type } = value;
+
+  if ($type) {
+    const { $descriptor } = value;
+
+    const { idProperty } = $descriptor;
+
+    if (idProperty) {
+      const { name } = idProperty;
+
+      const id = value.get(name);
+
+      if (id) {
+        return id;
+      } else {
+        return $type;
+      }
+    } else {
+      return $type;
+    }
+  }
+
+  return value;
+}

--- a/test/spec/testers/rule-tester-spec.js
+++ b/test/spec/testers/rule-tester-spec.js
@@ -1,9 +1,55 @@
-import { getTitle } from '../../../lib/testers/rule-tester';
+import BpmnModdle from 'bpmn-moddle';
+
+import {
+  expectEqual,
+  getTitle
+} from '../../../lib/testers/rule-tester';
 
 import { expect } from '../../helper';
 
 
 describe('rule-tester', function() {
+
+  let moddle;
+
+  beforeEach(function() {
+    moddle = new BpmnModdle();
+  });
+
+
+  describe('expectEqual', function() {
+
+    it('should not be equal', function() {
+
+      const a = { foo: 'bar' };
+      const b = { foo: 'baz' };
+
+      // then
+      expect(() => expectEqual(a, b)).to.throw();
+    });
+
+
+    it('should be equal (moddle element with ID)', function() {
+
+      const a = { node: moddle.create('bpmn:Task', { id: 'Task_1' }) };
+      const b = { node: 'Task_1' };
+
+      // then
+      expect(() => expectEqual(a, b)).not.to.throw();
+    });
+
+
+    it('should be equal (moddle element with no ID)', function() {
+
+      const a = { node: moddle.create('bpmn:Task') };
+      const b = { node: 'bpmn:Task' };
+
+      // then
+      expect(() => expectEqual(a, b)).not.to.throw();
+    });
+
+  });
+
 
   describe('#getTitle', function() {
 


### PR DESCRIPTION
Takes into account that reports might include instances of [`Base`](https://github.com/bpmn-io/moddle/blob/master/lib/base.js). Instances are replaced by ID or type allowing for tests like the following:

```js
RuleTester.verify('foo', rule, {
  [],
  [
    {
      moddleElement: ...,
      report: {
        id: 'Task_1'
        message: 'Foo',
        node: 'Task_1' // instance replaced by ID
      }
    }
  ]
});
```
