### PR TITLE
feat: rule tester accepts local config

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -14,11 +14,12 @@ function expectEqual(a, b) {
   assert.deepStrictEqual(JSON.stringify(a, replacer, 2), JSON.stringify(b, replacer, 2));
 }
 
-
 function verify(ruleName, rule, testCases) {
-  const linterConfig = {
-    rules: { [ruleName]: 2 }
-  };
+  function createLinterConfig(config = {}) {
+    return {
+      rules: { [ruleName]: [ 2, config ] }
+    };
+  }
 
   describe(`rules/${ruleName}`, function() {
 
@@ -33,13 +34,13 @@ function verify(ruleName, rule, testCases) {
 
     describe('should lint valid', function() {
 
-      testCases.valid.forEach(({ moddleElement, name, it: _it }, idx) => (
+      testCases.valid.forEach(({ config = {}, it: _it, moddleElement, name }, idx) => (
 
         (_it || it)(getTitle(idx, name), function() {
           return (
             Promise.resolve(moddleElement)
               .then(moddleRoot => {
-                return linter.lint(moddleRoot.root, linterConfig);
+                return linter.lint(moddleRoot.root, createLinterConfig(config));
               })
               .then(lintResults => {
                 expectEqual(lintResults, {});
@@ -54,7 +55,7 @@ function verify(ruleName, rule, testCases) {
 
     describe('should lint invalid', function() {
 
-      testCases.invalid.forEach(({ moddleElement, name, report, it: _it }, idx) => (
+      testCases.invalid.forEach(({ config = {}, it: _it, moddleElement, name, report }, idx) => (
 
         (_it || it)(getTitle(idx, name), function() {
 
@@ -78,7 +79,7 @@ function verify(ruleName, rule, testCases) {
           return (
             Promise.resolve(moddleElement)
               .then(moddleRoot => {
-                return linter.lint(moddleRoot.root, linterConfig);
+                return linter.lint(moddleRoot.root, createLinterConfig(config));
               })
               .then(lintResults => {
                 expectEqual(lintResults, expectedLintResults);
@@ -97,13 +98,6 @@ function verify(ruleName, rule, testCases) {
 function getTitle(idx, name) {
   return `test case #${ idx + 1 }${ name ? ` ${ name }`: '' }`;
 }
-
-module.exports = {
-  expectEqual,
-  verify,
-  getTitle,
-  replacer
-};
 
 function replacer(_, value) {
   if (!value) {
@@ -134,3 +128,10 @@ function replacer(_, value) {
 
   return value;
 }
+
+module.exports = {
+  expectEqual,
+  verify,
+  getTitle,
+  replacer
+};

--- a/test/spec/testers/rule-tester-spec.js
+++ b/test/spec/testers/rule-tester-spec.js
@@ -3,10 +3,14 @@ import BpmnModdle from 'bpmn-moddle';
 import {
   expectEqual,
   getTitle,
-  replacer
+  replacer,
+  verify
 } from '../../../lib/testers/rule-tester';
 
-import { expect } from '../../helper';
+import {
+  createModdle,
+  expect
+} from '../../helper';
 
 
 describe('rule-tester', function() {
@@ -18,7 +22,7 @@ describe('rule-tester', function() {
   });
 
 
-  describe('expectEqual', function() {
+  describe('#expectEqual', function() {
 
     it('should not be equal', function() {
 
@@ -82,7 +86,7 @@ describe('rule-tester', function() {
   });
 
 
-  describe('replacer', function() {
+  describe('#replacer', function() {
 
     it('should replace node', function() {
 
@@ -112,6 +116,36 @@ describe('rule-tester', function() {
           1
         ]
       }, null, 2));
+
+    });
+
+  });
+
+
+  describe('#verify', function() {
+
+    describe('with local config', function() {
+
+      verify('with-local-config', (config) => {
+        return {
+          check: (node, reporter) => {
+            reporter.report(node.get('id'), config);
+          }
+        };
+      }, {
+        valid: [],
+        invalid: [
+          {
+            name: 'with config',
+            config: 'foo',
+            moddleElement: createModdle('<bpmn:Task id="Task_1" />', 'bpmn:Task'),
+            report: {
+              id: 'Task_1',
+              message: 'foo'
+            }
+          }
+        ]
+      });
 
     });
 


### PR DESCRIPTION
Allows configurable rules to be tested.

### Example

```javascript
RuleTester.verify('my-rule', myRule, {
  valid: [],
  invalid: [
    {
      name: 'with config',
      config: {
        elements: [ 'bpmn:Task' ]
      },
      moddleElement: createModdle('<bpmn:Task id="Task_1" />', 'bpmn:Task'),
      report: {
        id: 'Task_1',
        message: 'Element of type <bpmn:Task> detected'
      }
    }
  ]
});
```