### PR TITLE
feat: add nested resolver

### DIFF
--- a/lib/resolver/nested-resolver.js
+++ b/lib/resolver/nested-resolver.js
@@ -1,0 +1,32 @@
+function NestedResolver(resolvers) {
+  this.resolvers = resolvers.reverse();
+}
+
+module.exports = NestedResolver;
+
+
+NestedResolver.prototype.resolveRule = function(pkg, ruleName) {
+  for (const resolver of this.resolvers) {
+    try {
+      return resolver.resolveRule(pkg, ruleName);
+    } catch (err) {
+
+      // ignore
+    }
+  }
+
+  throw new Error(`unknown rule <${pkg}/${ruleName}>`);
+};
+
+NestedResolver.prototype.resolveConfig = function(pkg, configName) {
+  for (const resolver of this.resolvers) {
+    try {
+      return resolver.resolveConfig(pkg, configName);
+    } catch (err) {
+
+      // ignore
+    }
+  }
+
+  throw new Error(`unknown config <${pkg}/${configName}>`);
+};

--- a/test/spec/resolver/nested-resolver-spec.js
+++ b/test/spec/resolver/nested-resolver-spec.js
@@ -1,0 +1,68 @@
+import NestedResolver from '../../../lib/resolver/nested-resolver';
+import StaticResolver from '../../../lib/resolver/static-resolver';
+
+import {
+  expect
+} from '../../helper';
+
+
+describe.only('resolver/nested-resolver', function() {
+
+  const resolver = new NestedResolver([
+    new StaticResolver({
+      'rule:plugin-a/foo': 'RULE',
+      'rule:plugin-a/bar': 'RULE',
+      'rule:plugin-a/baz': 'RULE',
+      'config:plugin-a/all': 'CONFIG'
+    }),
+    new StaticResolver({
+      'rule:plugin-a/bar': 'RULE',
+      'rule:plugin-b/foo': 'RULE',
+      'config:bar/recommended': {
+        'plugin-a/baz': 'off'
+      }
+    })
+  ]);
+
+
+  describe('#resolveRule', function() {
+
+    it('should resolve rule from plugin-a', async function() {
+
+      // when
+      const resolvedRule = await resolver.resolveRule('plugin-a', 'foo');
+
+      // then
+      expect(resolvedRule).to.eql('RULE');
+    });
+
+
+    it('should resolve rule from plugin-b', async function() {
+
+      // when
+      const resolvedRule = await resolver.resolveRule('plugin-b', 'foo');
+
+      // then
+      expect(resolvedRule).to.eql('RULE');
+    });
+
+
+    it('should throw on unresolved rule', async function() {
+
+      let error;
+
+      // when
+      try {
+        await resolver.resolveRule('plugin-a', 'non-existing-rule');
+      } catch (e) {
+        error = e;
+      }
+
+      // then
+      expect(error).to.exist;
+      expect(error.message).to.eql('unknown rule <plugin-a/non-existing-rule>');
+    });
+
+  });
+
+});


### PR DESCRIPTION
Adds nested resolver that combines one or more resolvers. Resolvers are prioritized from lowest to highest.

```javascript
const resolver = new NestedResolver([
  new StaticResolver(...), // lowest priority
  new StaticResolver(...),
  new StaticResolver(...) // highest priority
]);
```

---

Related to https://github.com/camunda/camunda-modeler/issues/3145