### PR TITLE
Change exclusive gateway to parallel gateway in no-implicit-split rule documentation

### DIFF
--- a/docs/rules/examples/no-bpmndi-correct.bpmn
+++ b/docs/rules/examples/no-bpmndi-correct.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1bgh4d7" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.5.0-dev">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="StartEvent_1" targetRef="Event_0a9blpi" />
+    <bpmn:endEvent id="Event_0a9blpi">
+      <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0a9blpi_di" bpmnElement="Event_0a9blpi">
+        <dc:Bounds x="282" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_19f2f3s_di" bpmnElement="SequenceFlow_1">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="282" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/docs/rules/examples/no-bpmndi-incorrect.bpmn
+++ b/docs/rules/examples/no-bpmndi-incorrect.bpmn
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1bgh4d7" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.5.0-dev">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="StartEvent_1" targetRef="Event_0a9blpi" />
+    <bpmn:endEvent id="Event_0a9blpi">
+      <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0a9blpi_di" bpmnElement="Event_0a9blpi">
+        <dc:Bounds x="282" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/docs/rules/examples/no-implicit-split-correct.bpmn
+++ b/docs/rules/examples/no-implicit-split-correct.bpmn
@@ -9,51 +9,51 @@
       <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
     </bpmn:task>
     <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="StartEvent_1" targetRef="Task_1" />
-    <bpmn:parallelGateway id="ExclusiveGateway_1">
+    <bpmn:parallelGateway id="ParallelGateway_1">
       <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_3</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_4</bpmn:outgoing>
     </bpmn:parallelGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="Task_1" targetRef="ExclusiveGateway_1" />
+    <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="Task_1" targetRef="ParallelGateway_1" />
     <bpmn:endEvent id="EndEvent_1">
       <bpmn:incoming>SequenceFlow_3</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_3" sourceRef="ExclusiveGateway_1" targetRef="EndEvent_1" />
+    <bpmn:sequenceFlow id="SequenceFlow_3" sourceRef="ParallelGateway_1" targetRef="EndEvent_1" />
     <bpmn:endEvent id="EndEvent_2">
       <bpmn:incoming>SequenceFlow_4</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_4" sourceRef="ExclusiveGateway_1" targetRef="EndEvent_2" />
+    <bpmn:sequenceFlow id="SequenceFlow_4" sourceRef="ParallelGateway_1" targetRef="EndEvent_2" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Task_1bhz1xa_di" bpmnElement="Task_1">
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
         <dc:Bounds x="270" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_19f2f3s_di" bpmnElement="SequenceFlow_1">
+      <bpmndi:BPMNEdge id="SequenceFlow_1_di" bpmnElement="SequenceFlow_1">
         <di:waypoint x="215" y="117" />
         <di:waypoint x="270" y="117" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="ExclusiveGateway_08n96ai_di" bpmnElement="ExclusiveGateway_1" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="ParallelGatewa_di" bpmnElement="ParallelGateway_1" isMarkerVisible="true">
         <dc:Bounds x="425" y="92" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_111d0vv_di" bpmnElement="SequenceFlow_2">
+      <bpmndi:BPMNEdge id="SequenceFlow_2_di" bpmnElement="SequenceFlow_2">
         <di:waypoint x="370" y="117" />
         <di:waypoint x="425" y="117" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="EndEvent_06otcgd_di" bpmnElement="EndEvent_1">
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
         <dc:Bounds x="532" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1j05k5f_di" bpmnElement="SequenceFlow_3">
+      <bpmndi:BPMNEdge id="SequenceFlow_3_di" bpmnElement="SequenceFlow_3">
         <di:waypoint x="475" y="117" />
         <di:waypoint x="532" y="117" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="EndEvent_02ukkj3_di" bpmnElement="EndEvent_2">
+      <bpmndi:BPMNShape id="EndEvent_2_di" bpmnElement="EndEvent_2">
         <dc:Bounds x="532" y="212" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_19ezikr_di" bpmnElement="SequenceFlow_4">
+      <bpmndi:BPMNEdge id="SequenceFlow_4_di" bpmnElement="SequenceFlow_4">
         <di:waypoint x="450" y="142" />
         <di:waypoint x="450" y="230" />
         <di:waypoint x="532" y="230" />

--- a/docs/rules/examples/no-implicit-split-correct.bpmn
+++ b/docs/rules/examples/no-implicit-split-correct.bpmn
@@ -9,11 +9,11 @@
       <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
     </bpmn:task>
     <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="StartEvent_1" targetRef="Task_1" />
-    <bpmn:exclusiveGateway id="ExclusiveGateway_1">
+    <bpmn:parallelGateway id="ExclusiveGateway_1">
       <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_3</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_4</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
+    </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="Task_1" targetRef="ExclusiveGateway_1" />
     <bpmn:endEvent id="EndEvent_1">
       <bpmn:incoming>SequenceFlow_3</bpmn:incoming>


### PR DESCRIPTION
The rule [no-implicit-split](https://github.com/bpmn-io/bpmnlint/blob/master/docs/rules/no-implicit-split.md) should show a parallel gateway instead of an exclusive gateway as correct usage. The text also describes that a parallel gateway should be used.

I changed the bpmn file for the correct model but I was not sure how to regenerate the corresponding png file for the documentation.