### PR TITLE
Resolve Explicitly Exported Plugin Rules

### DIFF
--- a/lib/resolver/node-resolver.js
+++ b/lib/resolver/node-resolver.js
@@ -44,11 +44,19 @@ NodeResolver.prototype.resolveRule = function(pkg, ruleName) {
     if (ruleName in rules) {
       const rule = rules[ruleName];
 
-      if (isString(rule)) {
-        return this.require(`${ pkg }/${ rule }`);
+      if (!isString(rule)) {
+        throw new Error('cannot resolve rule <' + ruleName + '> from <' + originalPkg + '>: illegal rule export (expected path reference)');
       }
 
-      throw new Error('Cannot resolve rule <' + ruleName + '> from <' + originalPkg + '>: illegal rule export (expected path reference)');
+      // local reference, resolved relative to pkg location
+      if (rule.startsWith('.')) {
+        const pkgDir = path.dirname(this.require.resolve(pkg));
+
+        return this.require(path.normalize(`${ pkgDir }/${ rule }`));
+      }
+
+      // absolute reference
+      return this.require(rule);
     }
   }
 
@@ -61,7 +69,7 @@ NodeResolver.prototype.resolveRule = function(pkg, ruleName) {
     }
   } catch (err) { /* ignore */ }
 
-  throw new Error('Cannot resolve rule <' + ruleName + '> from <' + originalPkg + '>');
+  throw new Error('cannot resolve rule <' + ruleName + '> from <' + originalPkg + '>');
 };
 
 NodeResolver.prototype.resolveConfig = function(pkg, configName) {
@@ -94,7 +102,7 @@ NodeResolver.prototype.resolveConfig = function(pkg, configName) {
   } catch (err) { /* ignore */ }
 
   throw new Error(
-    'Cannot resolve config <' + configName + '> from <' + originalPkg + '>'
+    'cannot resolve config <' + configName + '> from <' + originalPkg + '>'
   );
 };
 

--- a/lib/resolver/node-resolver.js
+++ b/lib/resolver/node-resolver.js
@@ -1,6 +1,8 @@
 const Module = require('module');
 const path = require('path');
 
+const { isString } = require('min-dash');
+
 /**
  * A resolver that locates rules and configurations
  * using node module resolution.
@@ -26,15 +28,40 @@ NodeResolver.prototype.resolveRule = function(pkg, ruleName) {
 
   pkg = this.normalizePkg(pkg);
 
+  let pkgInstance;
+
+  // (1) try resolving rule via $PKG.rules[$NAME]
+  try {
+    pkgInstance = this.require(pkg);
+  } catch (err) {
+
+    /* ignore */
+  }
+
+  if (pkgInstance) {
+    const rules = pkgInstance.rules || {};
+
+    if (ruleName in rules) {
+      const rule = rules[ruleName];
+
+      if (isString(rule)) {
+        return this.require(`${ pkg }/${ rule }`);
+      }
+
+      throw new Error('Cannot resolve rule <' + ruleName + '> from <' + originalPkg + '>: illegal rule export (expected path reference)');
+    }
+  }
+
+  // (2) try resolving rule via $PKG/rules/$NAME
   try {
     if (pkg === 'bpmnlint') {
       return this.requireLocal(`../../rules/${ruleName}`);
     } else {
       return this.require(`${pkg}/rules/${ruleName}`);
     }
-  } catch (err) {
-    throw new Error('Cannot resolve rule <' + ruleName + '> from <' + originalPkg + '>');
-  }
+  } catch (err) { /* ignore */ }
+
+  throw new Error('Cannot resolve rule <' + ruleName + '> from <' + originalPkg + '>');
 };
 
 NodeResolver.prototype.resolveConfig = function(pkg, configName) {
@@ -43,16 +70,7 @@ NodeResolver.prototype.resolveConfig = function(pkg, configName) {
 
   pkg = this.normalizePkg(pkg);
 
-  // resolve config via $PKG/config/$NAME
-  try {
-    if (pkg === 'bpmnlint') {
-      return this.requireLocal(`../../config/${configName}`);
-    } else {
-      return this.require(`${pkg}/config/${configName}`);
-    }
-  } catch (err) { /* ignore */ }
-
-  // resolve config via $PKG.configs[$NAME]
+  // (1) try resolving config via $PKG.configs[$NAME]
   try {
     const instance = this.require(pkg);
 
@@ -65,6 +83,15 @@ NodeResolver.prototype.resolveConfig = function(pkg, configName) {
 
     /* ignore */
   }
+
+  // (2) try resolving config via $PKG/config/$NAME
+  try {
+    if (pkg === 'bpmnlint') {
+      return this.requireLocal(`../../config/${configName}`);
+    } else {
+      return this.require(`${pkg}/config/${configName}`);
+    }
+  } catch (err) { /* ignore */ }
 
   throw new Error(
     'Cannot resolve config <' + configName + '> from <' + originalPkg + '>'

--- a/lib/resolver/node-resolver.js
+++ b/lib/resolver/node-resolver.js
@@ -52,7 +52,7 @@ NodeResolver.prototype.resolveRule = function(pkg, ruleName) {
       if (rule.startsWith('.')) {
         const pkgDir = path.dirname(this.require.resolve(pkg));
 
-        return this.require(path.normalize(`${ pkgDir }/${ rule }`));
+        return this.require(path.posix.normalize(`${ pkgDir }/${ rule }`));
       }
 
       // absolute reference

--- a/lib/support/compile-config.js
+++ b/lib/support/compile-config.js
@@ -156,7 +156,7 @@ function computeRuleImport(resolver, pkg, rule) {
   if (rule.startsWith('.')) {
     const pkgDir = path.dirname(resolver.require.resolve(pkg));
 
-    return path.normalize(`${ pkgDir }/${ rule }`);
+    return path.posix.normalize(`${ pkgDir }/${ rule }`);
   }
 
   // absolute reference

--- a/lib/support/compile-config.js
+++ b/lib/support/compile-config.js
@@ -57,7 +57,7 @@ Resolver.prototype.resolveRule = function(pkg, ruleName) {
   const rule = cache[pkg + '/' + ruleName];
 
   if (!rule) {
-    throw new Error('cannot resolve rule <' + pkg + '/' + ruleName + '>');
+    throw new Error('cannot resolve rule <' + pkg + '/' + ruleName + '>: not bundled');
   }
 
   return rule;
@@ -65,7 +65,7 @@ Resolver.prototype.resolveRule = function(pkg, ruleName) {
 
 Resolver.prototype.resolveConfig = function(pkg, configName) {
   throw new Error(
-    'cannot resolve config <' + configName + '> in <' + pkg +'>'
+    'cannot resolve config <' + configName + '> in <' + pkg +'>: not bundled'
   );
 };
 
@@ -127,16 +127,19 @@ function createImportStatement(pkg, ruleName, idx, resolver) {
     if (ruleName in rules) {
       const rule = rules[ruleName];
 
-      if (isString(rule)) {
-        return `
-import rule_${ idx } from '${pkg}/${ path.normalize(rule) }';
-
-cache['${ originalPkg }/${ ruleName }'] = rule_${ idx };`;
+      if (!isString(rule)) {
+        throw new Error(
+          `failed to bundle rule <${ruleName}> from <${ pkg }>: illegal rule export (expected path reference)`
+        );
       }
 
-      throw new Error(
-        `failed to bundle rule <${ruleName}> from <${ pkg }>: illegal rule export (expected path reference)`
-      );
+      const rulePath = computeRuleImport(resolver, pkg, rule);
+
+      return `
+import rule_${ idx } from '${rulePath}';
+
+cache['${ originalPkg }/${ ruleName }'] = rule_${ idx };`;
+
     }
   }
 
@@ -145,4 +148,17 @@ cache['${ originalPkg }/${ ruleName }'] = rule_${ idx };`;
 import rule_${ idx } from '${ pkg }/rules/${ ruleName }';
 
 cache['${ originalPkg }/${ ruleName }'] = rule_${ idx };`;
+}
+
+function computeRuleImport(resolver, pkg, rule) {
+
+  // local reference, resolved relative to pkg location
+  if (rule.startsWith('.')) {
+    const pkgDir = path.dirname(resolver.require.resolve(pkg));
+
+    return path.normalize(`${ pkgDir }/${ rule }`);
+  }
+
+  // absolute reference
+  return path.normalize(rule);
 }

--- a/lib/support/compile-config.js
+++ b/lib/support/compile-config.js
@@ -1,3 +1,7 @@
+const path = require('path').posix;
+
+const { isString } = require('min-dash');
+
 const Linter = require('../linter');
 
 const NodeResolver = require('../resolver/node-resolver');
@@ -93,12 +97,52 @@ export default bundle;
       pkg, ruleName
     } = linter.parseRuleName(key);
 
-    return `
-import rule_${idx} from '${resolver.normalizePkg(pkg)}/rules/${ruleName}';
-cache['${pkg}/${ruleName}'] = rule_${idx};`;
+    return createImportStatement(pkg, ruleName, idx, resolver);
   }).filter(e => e).join('\n');
 
-  return `${preambleCode}\n\n${importCode}`;
+  return `${preambleCode}${importCode}`;
 }
 
 module.exports = compileConfig;
+
+function requirePkg(resolver, pkg) {
+  try {
+    return resolver.require(pkg);
+  } catch (err) {
+    return null;
+  }
+}
+
+function createImportStatement(pkg, ruleName, idx, resolver) {
+  const originalPkg = pkg;
+
+  pkg = resolver.normalizePkg(pkg);
+
+  const pkgExport = requirePkg(resolver, pkg);
+
+  // (1) try resolving rule via $PKG.rules[$NAME]
+  if (pkgExport && pkgExport.rules) {
+    const rules = pkgExport.rules;
+
+    if (ruleName in rules) {
+      const rule = rules[ruleName];
+
+      if (isString(rule)) {
+        return `
+import rule_${ idx } from '${pkg}/${ path.normalize(rule) }';
+
+cache['${ originalPkg }/${ ruleName }'] = rule_${ idx };`;
+      }
+
+      throw new Error(
+        `failed to bundle rule <${ruleName}> from <${ pkg }>: illegal rule export (expected path reference)`
+      );
+    }
+  }
+
+  // (2) resolve rule via $PKG/rules/$NAME
+  return `
+import rule_${ idx } from '${ pkg }/rules/${ ruleName }';
+
+cache['${ originalPkg }/${ ruleName }'] = rule_${ idx };`;
+}

--- a/test/integration/bpmnlint-plugin-exported/package.json
+++ b/test/integration/bpmnlint-plugin-exported/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "bpmnlint-plugin-exported",
+  "version": "0.0.0",
+  "description": "A test bpmnlint plug-in that exports rules",
+  "main": "src/index.js",
+  "sideEffects": false
+}

--- a/test/integration/bpmnlint-plugin-exported/src/bar.js
+++ b/test/integration/bpmnlint-plugin-exported/src/bar.js
@@ -1,0 +1,7 @@
+module.exports = function bar() {
+  return {
+    check: function() {
+      console.log('bar');
+    }
+  };
+};

--- a/test/integration/bpmnlint-plugin-exported/src/bar.js
+++ b/test/integration/bpmnlint-plugin-exported/src/bar.js
@@ -1,7 +1,5 @@
 module.exports = function bar() {
   return {
-    check: function() {
-      console.log('bar');
-    }
+    check() {}
   };
 };

--- a/test/integration/bpmnlint-plugin-exported/src/foo.js
+++ b/test/integration/bpmnlint-plugin-exported/src/foo.js
@@ -1,7 +1,5 @@
 module.exports = function foo() {
   return {
-    check: function() {
-      console.log('foo');
-    }
+    check() {}
   };
 };

--- a/test/integration/bpmnlint-plugin-exported/src/foo.js
+++ b/test/integration/bpmnlint-plugin-exported/src/foo.js
@@ -1,0 +1,7 @@
+module.exports = function foo() {
+  return {
+    check: function() {
+      console.log('foo');
+    }
+  };
+};

--- a/test/integration/bpmnlint-plugin-exported/src/index.js
+++ b/test/integration/bpmnlint-plugin-exported/src/index.js
@@ -4,12 +4,14 @@ module.exports = {
       rules: {
         'foo': 'error',
         'bar': 'error',
-        'baz': 'error'
+        'baz': 'error',
+        'foo-absolute': 'error'
       }
     }
   },
   rules: {
-    'foo': 'src/foo',
-    'bar': 'src/bar'
+    'foo': './foo',
+    'bar': './bar',
+    'foo-absolute': 'bpmnlint-plugin-exported/src/foo'
   }
 };

--- a/test/integration/bpmnlint-plugin-exported/src/index.js
+++ b/test/integration/bpmnlint-plugin-exported/src/index.js
@@ -1,0 +1,15 @@
+module.exports = {
+  configs: {
+    recommended: {
+      rules: {
+        'foo': 'error',
+        'bar': 'error',
+        'baz': 'error'
+      }
+    }
+  },
+  rules: {
+    'foo': 'src/foo',
+    'bar': 'src/bar'
+  }
+};

--- a/test/integration/bundling-spec.js
+++ b/test/integration/bundling-spec.js
@@ -40,17 +40,20 @@ function test(bundler, options = { it: it }) {
     const actualFile = path.join(__dirname, `bundling/dist/app.${bundler}.js`);
     const expectedFile = path.join(__dirname, `bundling/test/app.${bundler}.expected.js`);
 
+    const root = process.cwd().replace(/[/\\. -]+/g, '_');
+
     if (process.env.UPDATE_FIXTURES) {
-      fs.writeFileSync(expectedFile, read(actualFile), 'utf8');
+      fs.writeFileSync(expectedFile, read(actualFile).split(root).join(''), 'utf8');
     }
 
     const actualContents = read(actualFile);
 
     // and
     expect(
-      actualContents, `${ actualFile } and ${ expectedFile } equal`
+      actualContents.split(root).join(''),
+      `${ actualFile } and ${ expectedFile } equal`
     ).to.eql(
-      read(expectedFile)
+      read(expectedFile).split(root).join('')
     );
 
     expect(actualContents).not.to.include('function bar()');

--- a/test/integration/bundling-spec.js
+++ b/test/integration/bundling-spec.js
@@ -10,7 +10,7 @@ import { expect } from 'chai';
 
   before(function() {
 
-    this.timeout(30000);
+    this.timeout(100000);
 
     return exec('install-local', [], __dirname + '/bundling');
   });
@@ -25,7 +25,9 @@ import { expect } from 'chai';
 
 function test(bundler, options = { it: it }) {
 
-  it(`should bundle with ${bundler}`, async function() {
+  options.it(`should bundle with ${bundler}`, async function() {
+
+    this.timeout(100000);
 
     // when
     const {
@@ -42,12 +44,17 @@ function test(bundler, options = { it: it }) {
       fs.writeFileSync(expectedFile, read(actualFile), 'utf8');
     }
 
+    const actualContents = read(actualFile);
+
     // and
     expect(
-      read(actualFile), `${ actualFile } and ${ expectedFile } equal`
+      actualContents, `${ actualFile } and ${ expectedFile } equal`
     ).to.eql(
       read(expectedFile)
     );
+
+    expect(actualContents).not.to.include('function bar()');
+    expect(actualContents).to.include('function foo()');
   });
 
 }

--- a/test/integration/bundling/package.json
+++ b/test/integration/bundling/package.json
@@ -17,6 +17,7 @@
   },
   "localDependencies": {
     "bpmnlint": "../../..",
-    "bpmnlint-plugin-test": "../bpmnlint-plugin-test"
+    "bpmnlint-plugin-test": "../bpmnlint-plugin-test",
+    "bpmnlint-plugin-exported": "../bpmnlint-plugin-exported"
   }
 }

--- a/test/integration/bundling/src/.bpmnlintrc
+++ b/test/integration/bundling/src/.bpmnlintrc
@@ -3,6 +3,7 @@
     "label-required": 1,
     "start-event-required": "info",
     "end-event-required": 2,
-    "bpmnlint-plugin-exported/foo": "error"
+    "bpmnlint-plugin-exported/foo": "error",
+    "bpmnlint-plugin-exported/foo-absolute": "error"
   }
 }

--- a/test/integration/bundling/src/.bpmnlintrc
+++ b/test/integration/bundling/src/.bpmnlintrc
@@ -2,6 +2,7 @@
   "rules": {
     "label-required": 1,
     "start-event-required": "info",
-    "end-event-required": 2
+    "end-event-required": 2,
+    "bpmnlint-plugin-exported/foo": "error"
   }
 }

--- a/test/integration/bundling/test/app.rollup.expected.js
+++ b/test/integration/bundling/test/app.rollup.expected.js
@@ -233,13 +233,11 @@
 
   var foo = function foo() {
     return {
-      check: function() {
-        console.log('foo');
-      }
+      check() {}
     };
   };
 
-  var rule_3 = /*@__PURE__*/getDefaultExportFromCjs(foo);
+  var rule_4 = /*@__PURE__*/getDefaultExportFromCjs(foo);
 
   const cache = {};
 
@@ -256,7 +254,7 @@
     const rule = cache[pkg + '/' + ruleName];
 
     if (!rule) {
-      throw new Error('cannot resolve rule <' + pkg + '/' + ruleName + '>');
+      throw new Error('cannot resolve rule <' + pkg + '/' + ruleName + '>: not bundled');
     }
 
     return rule;
@@ -264,7 +262,7 @@
 
   Resolver.prototype.resolveConfig = function(pkg, configName) {
     throw new Error(
-      'cannot resolve config <' + configName + '> in <' + pkg +'>'
+      'cannot resolve config <' + configName + '> in <' + pkg +'>: not bundled'
     );
   };
 
@@ -274,7 +272,8 @@
     "label-required": 1,
     "start-event-required": "info",
     "end-event-required": 2,
-    "exported/foo": "error"
+    "exported/foo": "error",
+    "exported/foo-absolute": "error"
   };
 
   const config = {
@@ -292,7 +291,9 @@
 
   cache['bpmnlint/end-event-required'] = rule_2;
 
-  cache['bpmnlint-plugin-exported/foo'] = rule_3;
+  cache['bpmnlint-plugin-exported/foo'] = rule_4;
+
+  cache['bpmnlint-plugin-exported/foo-absolute'] = rule_4;
 
   console.log(bundle);
 

--- a/test/integration/bundling/test/app.rollup.expected.js
+++ b/test/integration/bundling/test/app.rollup.expected.js
@@ -231,6 +231,16 @@
 
   var rule_2 = /*@__PURE__*/getDefaultExportFromCjs(endEventRequired);
 
+  var foo = function foo() {
+    return {
+      check: function() {
+        console.log('foo');
+      }
+    };
+  };
+
+  var rule_3 = /*@__PURE__*/getDefaultExportFromCjs(foo);
+
   const cache = {};
 
   /**
@@ -263,7 +273,8 @@
   const rules = {
     "label-required": 1,
     "start-event-required": "info",
-    "end-event-required": 2
+    "end-event-required": 2,
+    "exported/foo": "error"
   };
 
   const config = {
@@ -274,9 +285,14 @@
     resolver: resolver,
     config: config
   };
+
   cache['bpmnlint/label-required'] = rule_0;
+
   cache['bpmnlint/start-event-required'] = rule_1;
+
   cache['bpmnlint/end-event-required'] = rule_2;
+
+  cache['bpmnlint-plugin-exported/foo'] = rule_3;
 
   console.log(bundle);
 

--- a/test/integration/bundling/test/app.webpack.expected.js
+++ b/test/integration/bundling/test/app.webpack.expected.js
@@ -20,6 +20,8 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var bpmnlint_rules_start_event_required__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(bpmnlint_rules_start_event_required__WEBPACK_IMPORTED_MODULE_1__);
 /* harmony import */ var bpmnlint_rules_end_event_required__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! bpmnlint/rules/end-event-required */ "./node_modules/bpmnlint/rules/end-event-required.js");
 /* harmony import */ var bpmnlint_rules_end_event_required__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(bpmnlint_rules_end_event_required__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! bpmnlint-plugin-exported/src/foo */ "./node_modules/bpmnlint-plugin-exported/src/foo.js");
+/* harmony import */ var bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3__);
 
 const cache = {};
 
@@ -53,7 +55,8 @@ const resolver = new Resolver();
 const rules = {
   "label-required": 1,
   "start-event-required": "info",
-  "end-event-required": 2
+  "end-event-required": 2,
+  "exported/foo": "error"
 };
 
 const config = {
@@ -71,14 +74,35 @@ const bundle = {
 
 
 
-
 cache['bpmnlint/label-required'] = (bpmnlint_rules_label_required__WEBPACK_IMPORTED_MODULE_0___default());
+
 
 
 cache['bpmnlint/start-event-required'] = (bpmnlint_rules_start_event_required__WEBPACK_IMPORTED_MODULE_1___default());
 
 
+
 cache['bpmnlint/end-event-required'] = (bpmnlint_rules_end_event_required__WEBPACK_IMPORTED_MODULE_2___default());
+
+
+
+cache['bpmnlint-plugin-exported/foo'] = (bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3___default());
+
+/***/ }),
+
+/***/ "./node_modules/bpmnlint-plugin-exported/src/foo.js":
+/*!**********************************************************!*\
+  !*** ./node_modules/bpmnlint-plugin-exported/src/foo.js ***!
+  \**********************************************************/
+/***/ ((module) => {
+
+module.exports = function foo() {
+  return {
+    check: function() {
+      console.log('foo');
+    }
+  };
+};
 
 /***/ }),
 

--- a/test/integration/bundling/test/app.webpack.expected.js
+++ b/test/integration/bundling/test/app.webpack.expected.js
@@ -20,8 +20,8 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var bpmnlint_rules_start_event_required__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(bpmnlint_rules_start_event_required__WEBPACK_IMPORTED_MODULE_1__);
 /* harmony import */ var bpmnlint_rules_end_event_required__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! bpmnlint/rules/end-event-required */ "./node_modules/bpmnlint/rules/end-event-required.js");
 /* harmony import */ var bpmnlint_rules_end_event_required__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(bpmnlint_rules_end_event_required__WEBPACK_IMPORTED_MODULE_2__);
-/* harmony import */ var bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! bpmnlint-plugin-exported/src/foo */ "./node_modules/bpmnlint-plugin-exported/src/foo.js");
-/* harmony import */ var bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3__);
+/* harmony import */ var _test_integration_bundling_node_modules_bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! bpmnlint-plugin-exported/src/foo */ "./node_modules/bpmnlint-plugin-exported/src/foo.js");
+/* harmony import */ var _test_integration_bundling_node_modules_bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(_test_integration_bundling_node_modules_bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3__);
 
 const cache = {};
 
@@ -38,7 +38,7 @@ Resolver.prototype.resolveRule = function(pkg, ruleName) {
   const rule = cache[pkg + '/' + ruleName];
 
   if (!rule) {
-    throw new Error('cannot resolve rule <' + pkg + '/' + ruleName + '>');
+    throw new Error('cannot resolve rule <' + pkg + '/' + ruleName + '>: not bundled');
   }
 
   return rule;
@@ -46,7 +46,7 @@ Resolver.prototype.resolveRule = function(pkg, ruleName) {
 
 Resolver.prototype.resolveConfig = function(pkg, configName) {
   throw new Error(
-    'cannot resolve config <' + configName + '> in <' + pkg +'>'
+    'cannot resolve config <' + configName + '> in <' + pkg +'>: not bundled'
   );
 };
 
@@ -56,7 +56,8 @@ const rules = {
   "label-required": 1,
   "start-event-required": "info",
   "end-event-required": 2,
-  "exported/foo": "error"
+  "exported/foo": "error",
+  "exported/foo-absolute": "error"
 };
 
 const config = {
@@ -86,7 +87,11 @@ cache['bpmnlint/end-event-required'] = (bpmnlint_rules_end_event_required__WEBPA
 
 
 
-cache['bpmnlint-plugin-exported/foo'] = (bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3___default());
+cache['bpmnlint-plugin-exported/foo'] = (_test_integration_bundling_node_modules_bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3___default());
+
+
+
+cache['bpmnlint-plugin-exported/foo-absolute'] = (_test_integration_bundling_node_modules_bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3___default());
 
 /***/ }),
 
@@ -98,9 +103,7 @@ cache['bpmnlint-plugin-exported/foo'] = (bpmnlint_plugin_exported_src_foo__WEBPA
 
 module.exports = function foo() {
   return {
-    check: function() {
-      console.log('foo');
-    }
+    check() {}
   };
 };
 

--- a/test/integration/cli-spec.js
+++ b/test/integration/cli-spec.js
@@ -13,7 +13,7 @@ describe('cli', function() {
 
   before(function() {
 
-    this.timeout(30000);
+    this.timeout(100000);
 
     return exec('install-local', [], __dirname + '/cli');
   });
@@ -193,7 +193,7 @@ describe('cli', function() {
 
     before(function() {
 
-      this.timeout(30000);
+      this.timeout(100000);
 
       return exec('install-local', [], __dirname + '/cli/child');
     });
@@ -211,7 +211,7 @@ describe('cli', function() {
 
     before(function() {
 
-      this.timeout(30000);
+      this.timeout(100000);
 
       return exec('install-local', [], __dirname + '/cli/ns');
     });
@@ -367,7 +367,7 @@ function test(options) {
 
   (only ? it.only : it)(cmd.join(' ') + (cwd ? ` (cwd: ${cwd})` : ''), async function() {
 
-    this.timeout(3000);
+    this.timeout(100000);
 
     // when
     const {

--- a/test/integration/cli-spec.js
+++ b/test/integration/cli-spec.js
@@ -93,6 +93,11 @@ describe('cli', function() {
 
 
     test({
+      cmd: [ 'bpmnlint', '-c', 'exported.json', 'diagram.bpmn' ]
+    });
+
+
+    test({
       cmd: [ 'bpmnlint', 'complex.bpmn' ],
       expect: {
         code: 1,
@@ -179,7 +184,7 @@ describe('cli', function() {
 
     test({
       cmd: [ 'bpmnlint', '--version' ],
-      expct: {
+      expect: {
         code: 0,
         stderr: EMPTY,
         stdout: require('../../package.json').version
@@ -378,23 +383,23 @@ function test(options) {
       }
     });
 
+    const actualStderr = parseOutput(stdout, '---- STDERR');
+    const actualStdout = parseOutput(stdout, '---- STDOUT');
+
+    const actualCode = parseInt(
+      parseOutput(stdout, '---- CODE'), 10
+    );
+
     // then
-    if ('stderr' in expected) {
-      expectOutput(parseOutput(stdout, '---- STDERR'), expected.stderr);
+    if (expected.stderr || actualStderr) {
+      expectOutput(actualStderr, expected.stderr || '');
     }
 
-    if ('stdout' in expected) {
-      expectOutput(parseOutput(stdout, '---- STDOUT'), expected.stdout);
+    if (expected.stdout || actualStdout) {
+      expectOutput(actualStdout, expected.stdout || '');
     }
 
-
-    const code = expected.code || 0;
-
-    expect(
-      parseInt(
-        parseOutput(stdout, '---- CODE'), 10
-      )
-    ).to.eql(code);
+    expect(actualCode).to.eql(expected.code || 0);
   });
 
 }

--- a/test/integration/cli/exported.json
+++ b/test/integration/cli/exported.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "exported/foo": "warn",
+    "exported/foo-absolute": "warn"
+  }
+}

--- a/test/integration/cli/package.json
+++ b/test/integration/cli/package.json
@@ -7,13 +7,15 @@
   },
   "dependencies": {
     "bpmnlint": "file:../../..",
-    "bpmnlint-plugin-test": "file:../bpmnlint-plugin-test"
+    "bpmnlint-plugin-test": "file:../bpmnlint-plugin-test",
+    "bpmnlint-plugin-exported": "file:../bpmnlint-plugin-exported"
   },
   "devDependencies": {
     "execa": "^5.1.1"
   },
   "localDependencies": {
     "bpmnlint": "../../..",
-    "bpmnlint-plugin-test": "../bpmnlint-plugin-test"
+    "bpmnlint-plugin-test": "../bpmnlint-plugin-test",
+    "bpmnlint-plugin-exported": "../bpmnlint-plugin-exported"
   }
 }


### PR DESCRIPTION
Gives plugin authors the freedom to choose their own plugin structure (cf. https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/87).

Example:

```javascript
module.exports = {
  rules: {
    baz: './foo/bar/baz'
  }
};
```

[Similar to ESLint](https://eslint.org/docs/latest/extend/plugins#rules-in-plugins), just supporting path references over `require` calls; require calls cannot easily be bundled for the browser, cf. https://github.com/bpmn-io/bpmnlint/pull/99#discussion_r1154061535, https://github.com/bpmn-io/bpmnlint/pull/99#issuecomment-1521983034.

---

Related to https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/87