### PR TITLE
Fix compilation on Windows

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 test/integration/bundling/dist
 test/integration/bundling/test
+test/integration/compilation/test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,26 +11,18 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Use Node.js ${{matrix.node-version}}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{matrix.node-version}}
-    - name: Cache Node.js modules
-      uses: actions/cache@v2
-      with:
-        # npm cache files are stored in `~/.npm` on Linux/macOS
-        path: ~/.npm
-        key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.OS }}-node-
-          ${{ runner.OS }}-
+        cache: 'npm'
     - name: Install dependencies
       run: npm ci
     - name: Build
       run: COVERAGE=1 npm run all
     - name: Upload coverage
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
   Build-Nodes:
     runs-on: ${{ matrix.os }}
 
@@ -41,20 +33,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Use Node.js ${{matrix.node-version}}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{matrix.node-version}}
-    - name: Cache Node.js modules
-      uses: actions/cache@v2
-      with:
-        # npm cache files are stored in `~/.npm` on Linux/macOS
-        path: ~/.npm
-        key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.OS }}-node-
-          ${{ runner.OS }}-
+        cache: 'npm'
     - name: Install dependencies
       run: npm ci
     - name: Build
@@ -69,20 +53,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Use Node.js ${{matrix.node-version}}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{matrix.node-version}}
-    - name: Cache Node.js modules
-      uses: actions/cache@v2
-      with:
-        # npm cache files are stored in `~/.npm` on Linux/macOS
-        path: ~/.npm
-        key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.OS}}-node-
-          ${{ runner.OS }}-
+        cache: 'npm'
     - name: Install dependencies
       run: npm ci
     - name: Build

--- a/lib/support/compile-config.js
+++ b/lib/support/compile-config.js
@@ -156,7 +156,7 @@ function computeRuleImport(resolver, pkg, rule) {
   if (rule.startsWith('.')) {
     const pkgDir = path.dirname(resolver.require.resolve(pkg));
 
-    return path.posix.normalize(`${ pkgDir }/${ rule }`);
+    return path.normalize(`${ pkgDir }/${ rule }`);
   }
 
   // absolute reference

--- a/lib/support/compile-config.js
+++ b/lib/support/compile-config.js
@@ -1,4 +1,4 @@
-const path = require('path').posix;
+const path = require('path');
 
 const { isString } = require('min-dash');
 
@@ -154,11 +154,13 @@ function computeRuleImport(resolver, pkg, rule) {
 
   // local reference, resolved relative to pkg location
   if (rule.startsWith('.')) {
-    const pkgDir = path.dirname(resolver.require.resolve(pkg));
+    const pkgMain = resolver.require.resolve(pkg);
 
-    return path.normalize(`${ pkgDir }/${ rule }`);
+    const pkgDir = path.dirname(pkgMain.split(path.sep).join(path.posix.sep));
+
+    return path.posix.normalize(path.posix.join(pkgDir, rule));
   }
 
   // absolute reference
-  return path.normalize(rule);
+  return path.posix.normalize(rule);
 }

--- a/test/integration/compilation/.gitignore
+++ b/test/integration/compilation/.gitignore
@@ -1,0 +1,1 @@
+test/bpmnlintrc.actual.js

--- a/test/integration/compilation/compile.js
+++ b/test/integration/compilation/compile.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+
+const compileConfig = require('bpmnlint/lib/support/compile-config');
+
+const config = {
+  extends: [
+    'plugin:test/recommended',
+    'plugin:exported/recommended'
+  ]
+};
+
+compileConfig(config).then(code => fs.writeFileSync('test/bpmnlintrc.actual.js', code)).catch(err => {
+  console.error(err);
+
+  process.exit(1);
+});

--- a/test/integration/compilation/package.json
+++ b/test/integration/compilation/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "compilation",
+  "description": "Simple project to test bpmnlint rule compilation",
+  "private": true,
+  "scripts": {
+    "compile": "node compile.js"
+  },
+  "localDependencies": {
+    "bpmnlint": "../../..",
+    "bpmnlint-plugin-test": "../bpmnlint-plugin-test",
+    "bpmnlint-plugin-exported": "../bpmnlint-plugin-exported"
+  }
+}

--- a/test/integration/compilation/test/bpmnlintrc.expected.js
+++ b/test/integration/compilation/test/bpmnlintrc.expected.js
@@ -1,0 +1,170 @@
+
+const cache = {};
+
+/**
+ * A resolver that caches rules and configuration as part of the bundle,
+ * making them accessible in the browser.
+ *
+ * @param {Object} cache
+ */
+function Resolver() {}
+
+Resolver.prototype.resolveRule = function(pkg, ruleName) {
+
+  const rule = cache[pkg + '/' + ruleName];
+
+  if (!rule) {
+    throw new Error('cannot resolve rule <' + pkg + '/' + ruleName + '>: not bundled');
+  }
+
+  return rule;
+};
+
+Resolver.prototype.resolveConfig = function(pkg, configName) {
+  throw new Error(
+    'cannot resolve config <' + configName + '> in <' + pkg +'>: not bundled'
+  );
+};
+
+const resolver = new Resolver();
+
+const rules = {
+  "conditional-flows": "error",
+  "end-event-required": "error",
+  "event-sub-process-typed-start-event": "error",
+  "fake-join": "warn",
+  "label-required": "error",
+  "no-bpmndi": "error",
+  "no-complex-gateway": "error",
+  "no-disconnected": "warn",
+  "no-duplicate-sequence-flows": "error",
+  "no-gateway-join-fork": "error",
+  "no-implicit-split": "error",
+  "no-implicit-end": "error",
+  "no-implicit-start": "error",
+  "no-inclusive-gateway": "error",
+  "no-overlapping-elements": "warn",
+  "single-blank-start-event": "error",
+  "single-event-definition": "error",
+  "start-event-required": "error",
+  "sub-process-blank-start-event": "error",
+  "superfluous-gateway": "warn",
+  "test/no-label-foo": "error",
+  "exported/foo": "error",
+  "exported/bar": "error",
+  "exported/baz": "error",
+  "exported/foo-absolute": "error"
+};
+
+const config = {
+  rules: rules
+};
+
+const bundle = {
+  resolver: resolver,
+  config: config
+};
+
+export { resolver, config };
+
+export default bundle;
+
+import rule_0 from 'bpmnlint/rules/conditional-flows';
+
+cache['bpmnlint/conditional-flows'] = rule_0;
+
+import rule_1 from 'bpmnlint/rules/end-event-required';
+
+cache['bpmnlint/end-event-required'] = rule_1;
+
+import rule_2 from 'bpmnlint/rules/event-sub-process-typed-start-event';
+
+cache['bpmnlint/event-sub-process-typed-start-event'] = rule_2;
+
+import rule_3 from 'bpmnlint/rules/fake-join';
+
+cache['bpmnlint/fake-join'] = rule_3;
+
+import rule_4 from 'bpmnlint/rules/label-required';
+
+cache['bpmnlint/label-required'] = rule_4;
+
+import rule_5 from 'bpmnlint/rules/no-bpmndi';
+
+cache['bpmnlint/no-bpmndi'] = rule_5;
+
+import rule_6 from 'bpmnlint/rules/no-complex-gateway';
+
+cache['bpmnlint/no-complex-gateway'] = rule_6;
+
+import rule_7 from 'bpmnlint/rules/no-disconnected';
+
+cache['bpmnlint/no-disconnected'] = rule_7;
+
+import rule_8 from 'bpmnlint/rules/no-duplicate-sequence-flows';
+
+cache['bpmnlint/no-duplicate-sequence-flows'] = rule_8;
+
+import rule_9 from 'bpmnlint/rules/no-gateway-join-fork';
+
+cache['bpmnlint/no-gateway-join-fork'] = rule_9;
+
+import rule_10 from 'bpmnlint/rules/no-implicit-split';
+
+cache['bpmnlint/no-implicit-split'] = rule_10;
+
+import rule_11 from 'bpmnlint/rules/no-implicit-end';
+
+cache['bpmnlint/no-implicit-end'] = rule_11;
+
+import rule_12 from 'bpmnlint/rules/no-implicit-start';
+
+cache['bpmnlint/no-implicit-start'] = rule_12;
+
+import rule_13 from 'bpmnlint/rules/no-inclusive-gateway';
+
+cache['bpmnlint/no-inclusive-gateway'] = rule_13;
+
+import rule_14 from 'bpmnlint/rules/no-overlapping-elements';
+
+cache['bpmnlint/no-overlapping-elements'] = rule_14;
+
+import rule_15 from 'bpmnlint/rules/single-blank-start-event';
+
+cache['bpmnlint/single-blank-start-event'] = rule_15;
+
+import rule_16 from 'bpmnlint/rules/single-event-definition';
+
+cache['bpmnlint/single-event-definition'] = rule_16;
+
+import rule_17 from 'bpmnlint/rules/start-event-required';
+
+cache['bpmnlint/start-event-required'] = rule_17;
+
+import rule_18 from 'bpmnlint/rules/sub-process-blank-start-event';
+
+cache['bpmnlint/sub-process-blank-start-event'] = rule_18;
+
+import rule_19 from 'bpmnlint/rules/superfluous-gateway';
+
+cache['bpmnlint/superfluous-gateway'] = rule_19;
+
+import rule_20 from 'bpmnlint-plugin-test/rules/no-label-foo';
+
+cache['bpmnlint-plugin-test/no-label-foo'] = rule_20;
+
+import rule_21 from '$ROOT/test/integration/compilation/node_modules/bpmnlint-plugin-exported/src/foo';
+
+cache['bpmnlint-plugin-exported/foo'] = rule_21;
+
+import rule_22 from '$ROOT/test/integration/compilation/node_modules/bpmnlint-plugin-exported/src/bar';
+
+cache['bpmnlint-plugin-exported/bar'] = rule_22;
+
+import rule_23 from 'bpmnlint-plugin-exported/rules/baz';
+
+cache['bpmnlint-plugin-exported/baz'] = rule_23;
+
+import rule_24 from 'bpmnlint-plugin-exported/src/foo';
+
+cache['bpmnlint-plugin-exported/foo-absolute'] = rule_24;

--- a/test/integration/compile-spec.js
+++ b/test/integration/compile-spec.js
@@ -1,0 +1,93 @@
+import path from 'path';
+import fs from 'fs';
+
+import execa from 'execa';
+
+import { expect } from 'chai';
+
+
+describe('compile', function() {
+
+  before(function() {
+
+    this.timeout(100000);
+
+    return exec('install-local', [], __dirname + '/compilation');
+  });
+
+
+  test();
+
+});
+
+
+function test(options = { it: it }) {
+
+  options.it('should compile configuration', async function() {
+
+    this.timeout(100000);
+
+    // when
+    const {
+      exitCode
+    } = await exec('npm', [ 'run', 'compile' ], path.join(__dirname, 'compilation'), {
+      stdio: 'inherit'
+    });
+
+    // then
+    expect(exitCode).to.eql(0);
+
+    const actualFile = path.join(__dirname, 'compilation', 'test', 'bpmnlintrc.actual.js');
+    const expectedFile = path.join(__dirname, 'compilation', 'test', 'bpmnlintrc.expected.js');
+
+    const root = path.posix.normalize(
+      process.cwd().split(path.sep).join(path.posix.sep)
+    );
+
+    if (process.env.UPDATE_FIXTURES) {
+      fs.writeFileSync(expectedFile, read(actualFile).split(root).join('$ROOT'), 'utf8');
+    }
+
+    const actualContents = read(actualFile).split(root).join('$ROOT');
+
+    // and
+    expect(
+      actualContents,
+      `${ actualFile } and ${ expectedFile } equal`
+    ).to.eql(
+      read(expectedFile)
+    );
+
+    expect(actualContents).to.match(
+      /import rule_[0-9]+ from 'bpmnlint-plugin-test\/rules\/no-label-foo'/
+    );
+
+    expect(actualContents).to.match(
+      /import rule_[0-9]+ from '\$ROOT\/test\/integration\/compilation\/node_modules\/bpmnlint-plugin-exported\/src\/bar'/
+    );
+
+    expect(actualContents).to.match(
+      /import rule_[0-9]+ from 'bpmnlint-plugin-exported\/rules\/baz'/
+    );
+
+    expect(actualContents).to.match(
+      /import rule_[0-9]+ from 'bpmnlint-plugin-exported\/src\/foo'/
+    );
+
+  });
+
+}
+
+function exec(prog, args, cwd, options = {}) {
+
+  return execa(prog, args, {
+    cwd,
+    ...options
+  });
+}
+
+function read(fileName) {
+  expect(fs.existsSync(fileName), `${fileName} exists`).to.be.true;
+
+  return fs.readFileSync(fileName, 'utf8').replace(/\r\n/g, '\n').replace(/\t/g, '  ');
+}


### PR DESCRIPTION
This fixes https://github.com/bpmn-io/bpmnlint/issues/112, which turned out to be a :window: only issue.

As it stands we need to properly convert paths between :window: and :penguin: _before_ we normalize or join, as these node utilities do a bad (to no) job of converting.