### PR TITLE
Compile rules using package local imports

### DIFF
--- a/lib/support/compile-config.js
+++ b/lib/support/compile-config.js
@@ -133,7 +133,7 @@ function createImportStatement(pkg, ruleName, idx, resolver) {
         );
       }
 
-      const rulePath = computeRuleImport(resolver, pkg, rule);
+      const rulePath = computeRuleImport(resolver, pkg, originalPkg, rule);
 
       return `
 import rule_${ idx } from '${rulePath}';
@@ -150,17 +150,23 @@ import rule_${ idx } from '${ pkg }/rules/${ ruleName }';
 cache['${ originalPkg }/${ ruleName }'] = rule_${ idx };`;
 }
 
-function computeRuleImport(resolver, pkg, rule) {
+function computeRuleImport(resolver, pkg, originalPkg, rule) {
 
   // local reference, resolved relative to pkg location
   if (rule.startsWith('.')) {
-    const pkgMain = resolver.require.resolve(pkg);
+    const pkgJsonPath = resolver.require.resolve(`${ pkg }/package.json`);
 
-    const pkgDir = path.dirname(pkgMain.split(path.sep).join(path.posix.sep));
+    const pkgMainPath = resolver.require.resolve(pkg);
 
-    return path.posix.normalize(path.posix.join(pkgDir, rule));
+    const relativePkgMainPath = path.relative(
+      path.dirname(pkgJsonPath),
+      path.dirname(pkgMainPath)
+    );
+
+    return path.posix.normalize(`${ originalPkg }/${ relativePkgMainPath }/${ rule }`);
+  } else {
+
+    // absolute reference
+    return path.posix.normalize(rule);
   }
-
-  // absolute reference
-  return path.posix.normalize(rule);
 }

--- a/test/integration/bundling/test/app.webpack.expected.js
+++ b/test/integration/bundling/test/app.webpack.expected.js
@@ -20,8 +20,8 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var bpmnlint_rules_start_event_required__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(bpmnlint_rules_start_event_required__WEBPACK_IMPORTED_MODULE_1__);
 /* harmony import */ var bpmnlint_rules_end_event_required__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! bpmnlint/rules/end-event-required */ "./node_modules/bpmnlint/rules/end-event-required.js");
 /* harmony import */ var bpmnlint_rules_end_event_required__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(bpmnlint_rules_end_event_required__WEBPACK_IMPORTED_MODULE_2__);
-/* harmony import */ var _test_integration_bundling_node_modules_bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! bpmnlint-plugin-exported/src/foo */ "./node_modules/bpmnlint-plugin-exported/src/foo.js");
-/* harmony import */ var _test_integration_bundling_node_modules_bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(_test_integration_bundling_node_modules_bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3__);
+/* harmony import */ var bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! bpmnlint-plugin-exported/src/foo */ "./node_modules/bpmnlint-plugin-exported/src/foo.js");
+/* harmony import */ var bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3__);
 
 const cache = {};
 
@@ -87,11 +87,11 @@ cache['bpmnlint/end-event-required'] = (bpmnlint_rules_end_event_required__WEBPA
 
 
 
-cache['bpmnlint-plugin-exported/foo'] = (_test_integration_bundling_node_modules_bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3___default());
+cache['bpmnlint-plugin-exported/foo'] = (bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3___default());
 
 
 
-cache['bpmnlint-plugin-exported/foo-absolute'] = (_test_integration_bundling_node_modules_bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3___default());
+cache['bpmnlint-plugin-exported/foo-absolute'] = (bpmnlint_plugin_exported_src_foo__WEBPACK_IMPORTED_MODULE_3___default());
 
 /***/ }),
 

--- a/test/integration/compilation/test/bpmnlintrc.expected.js
+++ b/test/integration/compilation/test/bpmnlintrc.expected.js
@@ -153,11 +153,11 @@ import rule_20 from 'bpmnlint-plugin-test/rules/no-label-foo';
 
 cache['bpmnlint-plugin-test/no-label-foo'] = rule_20;
 
-import rule_21 from '$ROOT/test/integration/compilation/node_modules/bpmnlint-plugin-exported/src/foo';
+import rule_21 from 'bpmnlint-plugin-exported/src/foo';
 
 cache['bpmnlint-plugin-exported/foo'] = rule_21;
 
-import rule_22 from '$ROOT/test/integration/compilation/node_modules/bpmnlint-plugin-exported/src/bar';
+import rule_22 from 'bpmnlint-plugin-exported/src/bar';
 
 cache['bpmnlint-plugin-exported/bar'] = rule_22;
 

--- a/test/integration/compile-spec.js
+++ b/test/integration/compile-spec.js
@@ -63,7 +63,7 @@ function test(options = { it: it }) {
     );
 
     expect(actualContents).to.match(
-      /import rule_[0-9]+ from '\$ROOT\/test\/integration\/compilation\/node_modules\/bpmnlint-plugin-exported\/src\/bar'/
+      /import rule_[0-9]+ from 'bpmnlint-plugin-exported\/src\/bar'/
     );
 
     expect(actualContents).to.match(

--- a/test/spec/support/compile-config-spec.js
+++ b/test/spec/support/compile-config-spec.js
@@ -4,6 +4,8 @@ const NodeResolver = require('../../../lib/resolver/node-resolver');
 
 const compileConfig = require('../../../lib/support/compile-config');
 
+const os = require('os');
+
 
 describe('support/compile-config', function() {
 
@@ -95,17 +97,27 @@ describe('support/compile-config', function() {
             throw new Error('not found: ' + path);
           },
           function __resolve(path) {
+            if (path === 'bpmnlint-plugin-foreign/package.json') {
 
-            if (path === 'bpmnlint-plugin-foreign') {
-              return 'bpmnlint-plugin-foreign/lib/index.js';
+              if (os.platform() === 'win32') {
+                return 'C:\\\\bpmnlint-plugin-foreign\\package.json';
+              } else {
+                return '/bpmnlint-plugin-foreign/package.json';
+              }
             }
 
+            if (path === 'bpmnlint-plugin-foreign') {
+              if (os.platform() === 'win32') {
+                return 'C:\\\\bpmnlint-plugin-foreign\\lib\\index.js';
+              } else {
+                return '/bpmnlint-plugin-foreign/lib/index.js';
+              }
+            }
 
             throw new Error('not found: ' + path);
           }
         )
       });
-
 
       // when
       const code = await compileConfig({
@@ -153,6 +165,10 @@ describe('support/compile-config', function() {
             throw new Error('not found: ' + path);
           },
           function __resolve(path) {
+            if (path === './package.json') {
+              return 'bpmnlint-plugin-local/package.json';
+            }
+
             if (path === '.') {
               return 'bpmnlint-plugin-local/lib/index.js';
             }
@@ -161,7 +177,6 @@ describe('support/compile-config', function() {
           }
         )
       });
-
 
       // when
       const code = await compileConfig({


### PR DESCRIPTION
Previously we would use the absolute path to compile packages with custom paths.

This PR changes the behavior to compile to package local imports.