### PR TITLE
Fix `no-overlapping-elements` to handle missing child element DI

### DIFF
--- a/rules/no-overlapping-elements.js
+++ b/rules/no-overlapping-elements.js
@@ -67,6 +67,11 @@ function checkProcess(node, elementsToReport, elementsOutsideToReport, diObjects
   // check child elements outside parent boundary
   // TODO: Skipped DataSoreReferences for now
   flowElements.filter(element => !is(element, 'bpmn:DataStoreReference')).forEach(element => {
+
+    if (!diObjects.has(element)) {
+      return;
+    }
+
     if (isOutsideParentBoundary(diObjects.get(element).bounds, parentDi.bounds)) {
       elementsOutsideToReport.add(element);
     }

--- a/test/rules/no-overlapping-elements.mjs
+++ b/test/rules/no-overlapping-elements.mjs
@@ -29,6 +29,9 @@ RuleTester.verify('no-overlapping-elements', rule, {
     },
     {
       moddleElement: readModdle(__dirname + '/no-overlapping-elements/valid-subprocess-collapsed.bpmn')
+    },
+    {
+      moddleElement: readModdle(__dirname + '/no-overlapping-elements/ignore-missing-di.bpmn')
     }
   ],
   invalid: [

--- a/test/rules/no-overlapping-elements/ignore-missing-di.bpmn
+++ b/test/rules/no-overlapping-elements/ignore-missing-di.bpmn
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1e3p5jm" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.12.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.19.0">
+  <bpmn:process id="Process_009qqmc" isExecutable="true">
+    <bpmn:subProcess id="SUB_PROCESS">
+      <bpmn:task id="TASK_NO_DI" name="TASK_NO_DI" />
+      <bpmn:dataStoreReference id="DATA_STORE_REFERENCE" name="DATA_STORE_REFERENCE" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="SUB_PROCESS_NO_DI"></bpmn:subProcess>
+    <bpmn:subProcess id="SUB_PROCESS_NO_DI_CHILDREN">
+      <bpmn:task id="TASK" name="TASK" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="SUB_PROCESS_PLANE">
+      <bpmn:task id="TASK_PLANE_NO_DI" name="TASK" />
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_009qqmc">
+      <bpmndi:BPMNShape id="TASK_DI" bpmnElement="TASK" isExpanded="true">
+        <dc:Bounds x="60" y="90" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SUB_PROCESS_DI" bpmnElement="SUB_PROCESS" isExpanded="true">
+        <dc:Bounds x="160" y="90" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DATA_STORE_REFERENCE_di" bpmnElement="DATA_STORE_REFERENCE">
+        <dc:Bounds x="535" y="205" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="521" y="262" width="79" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+    <bpmndi:BPMNPlane id="BPMNPlane_2" bpmnElement="SUB_PROCESS_PLANE">
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
The linter would otherwise blow up.