### PR TITLE
fix: no no-implicit-end error on compensation activity

### DIFF
--- a/rules/helper.js
+++ b/rules/helper.js
@@ -28,6 +28,8 @@ function disallowNodeType(type) {
 
 }
 
+module.exports.disallowNodeType = disallowNodeType;
+
 /**
  * Find a parent for the given element
  *
@@ -57,4 +59,3 @@ function findParent(node, type) {
 }
 
 module.exports.findParent = findParent;
-module.exports.disallowNodeType = disallowNodeType;

--- a/rules/helper.js
+++ b/rules/helper.js
@@ -28,4 +28,33 @@ function disallowNodeType(type) {
 
 }
 
+/**
+ * Find a parent for the given element
+ *
+ * @param {ModdleElement} node
+ *
+ *  @param {String} type
+ *
+ * @return {ModdleElement} element
+ */
+
+function findParent(node, type) {
+  if (!node) {
+    return null;
+  }
+
+  const parent = node.$parent;
+
+  if (!parent) {
+    return node;
+  }
+
+  if (is(parent, type)) {
+    return parent;
+  }
+
+  return findParent(parent, type);
+}
+
+module.exports.findParent = findParent;
 module.exports.disallowNodeType = disallowNodeType;

--- a/rules/no-implicit-end.js
+++ b/rules/no-implicit-end.js
@@ -28,15 +28,19 @@ module.exports = function() {
     );
   }
 
-  function isConnectedToActivity(node) {
+  function hasCompensationActivity(node) {
     const parent = findParent(node, 'bpmn:Process');
+
     const artifacts = parent.artifacts || [];
+
     return artifacts.some((element) => {
-      return (
-        is(element, 'bpmn:Association') &&
-        is(element.sourceRef, 'bpmn:BoundaryEvent') &&
-        element.sourceRef.id === node.id
-      );
+      if (!is(element, 'bpmn:Association')) {
+        return false;
+      }
+
+      const source = element.sourceRef;
+
+      return source.id === node.id;
     });
   }
 
@@ -59,10 +63,8 @@ module.exports = function() {
       return false;
     }
 
-    if (is(node, 'bpmn:BoundaryEvent')) {
-      if (isCompensationEvent(node) && isConnectedToActivity(node)) {
-        return false;
-      }
+    if (is(node, 'bpmn:BoundaryEvent') && isCompensationEvent(node) && hasCompensationActivity(node)) {
+      return false;
     }
 
     if (is(node, 'bpmn:Task') && isForCompensation(node)) {

--- a/test/rules/no-implicit-end/valid.bpmn
+++ b/test/rules/no-implicit-end/valid.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sid-38422fae-e03e-43a3-bef4-bd33b32041b2" targetNamespace="http://bpmn.io/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0">
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sid-38422fae-e03e-43a3-bef4-bd33b32041b2" targetNamespace="http://bpmn.io/bpmn" exporter="Camunda Modeler" exporterVersion="5.25.0">
   <process id="PROCESS" isExecutable="false">
     <endEvent id="END_EVENT" name="END_EVENT">
       <incoming>Flow_1w3680k</incoming>
@@ -41,7 +41,24 @@
       <linkEventDefinition id="LinkEventDefinition_1eotqp9" name="" />
     </intermediateCatchEvent>
     <sequenceFlow id="Flow_0az7c7m" sourceRef="LINK_CATCH" targetRef="INTERMEDIATE_EVENT" />
+    <task id="Activity_157mlpt" name="TASK">
+      <incoming>Flow_16zubsb</incoming>
+      <outgoing>Flow_044vrdf</outgoing>
+    </task>
+    <boundaryEvent id="COMPENSATION_ACTIVITY_EVENT" name="COMPENSATION ACTIVITY EVENT" attachedToRef="Activity_157mlpt">
+      <compensateEventDefinition id="CompensateEventDefinition_0gqzw6g" />
+    </boundaryEvent>
+    <task id="COMPENSATION_ACTIVITY" name="COMPENSATION ACTIVITY" isForCompensation="true" />
+    <startEvent id="Event_0q72fbq" name="START_EVENT">
+      <outgoing>Flow_16zubsb</outgoing>
+    </startEvent>
+    <sequenceFlow id="Flow_16zubsb" sourceRef="Event_0q72fbq" targetRef="Activity_157mlpt" />
+    <endEvent id="Event_109rdfb" name="END_EVENT">
+      <incoming>Flow_044vrdf</incoming>
+    </endEvent>
+    <sequenceFlow id="Flow_044vrdf" sourceRef="Activity_157mlpt" targetRef="Event_109rdfb" />
     <group id="Group_14ev8gw" />
+    <association id="Association_1ixehz7" associationDirection="One" sourceRef="COMPENSATION_ACTIVITY_EVENT" targetRef="COMPENSATION_ACTIVITY" />
   </process>
   <bpmndi:BPMNDiagram id="BpmnDiagram_1">
     <bpmndi:BPMNPlane id="BpmnPlane_1" bpmnElement="PROCESS">
@@ -85,35 +102,63 @@
           <omgdc:Bounds x="564" y="145" width="73" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1mfo1h4_di" bpmnElement="LINK_CATCH">
-        <omgdc:Bounds x="362" y="122" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_157mlpt_di" bpmnElement="Activity_157mlpt">
+        <omgdc:Bounds x="630" y="540" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="COMPENSATION_ACTIVITY_di" bpmnElement="COMPENSATION_ACTIVITY">
+        <omgdc:Bounds x="770" y="660" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0q72fbq_di" bpmnElement="Event_0q72fbq">
+        <omgdc:Bounds x="522" y="562" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <omgdc:Bounds x="346" y="98" width="68" height="14" />
+          <omgdc:Bounds x="501" y="605" width="78" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_109rdfb_di" bpmnElement="Event_109rdfb">
+        <omgdc:Bounds x="802" y="562" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="787" y="605" width="67" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0lxy7o7_di" bpmnElement="EVENT_SUB" isExpanded="true">
         <omgdc:Bounds x="940" y="90" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1mfo1h4_di" bpmnElement="LINK_CATCH">
+        <omgdc:Bounds x="362" y="122" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="346" y="98" width="68" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1ixehz7_di" bpmnElement="Association_1ixehz7">
+        <di:waypoint x="700" y="638" />
+        <di:waypoint x="700" y="700" />
+        <di:waypoint x="770" y="700" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1gmxxzr_di" bpmnElement="COMPENSATION_ACTIVITY_EVENT">
+        <omgdc:Bounds x="682" y="602" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="655" y="645" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_16zubsb_di" bpmnElement="Flow_16zubsb">
+        <di:waypoint x="558" y="580" />
+        <di:waypoint x="630" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_044vrdf_di" bpmnElement="Flow_044vrdf">
+        <di:waypoint x="730" y="580" />
+        <di:waypoint x="802" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Group_14ev8gw_di" bpmnElement="Group_14ev8gw">
+        <omgdc:Bounds x="560" y="190" width="300" height="300" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0nahpgz_di" bpmnElement="BOUNDARY">
         <omgdc:Bounds x="302" y="322" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <omgdc:Bounds x="289" y="365" width="63" height="14" />
         </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_04fxx9j_di" bpmnElement="Flow_04fxx9j">
-        <di:waypoint x="338" y="340" />
-        <di:waypoint x="358" y="340" />
-        <di:waypoint x="358" y="450" />
-        <di:waypoint x="295" y="450" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0az7c7m_di" bpmnElement="Flow_0az7c7m">
-        <di:waypoint x="380" y="158" />
-        <di:waypoint x="380" y="230" />
-        <di:waypoint x="288" y="230" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Group_14ev8gw_di" bpmnElement="Group_14ev8gw">
-        <omgdc:Bounds x="560" y="190" width="300" height="300" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_1m6hogu_di" bpmnElement="Flow_1m6hogu">
         <di:waypoint x="270" y="158" />
@@ -130,6 +175,17 @@
       <bpmndi:BPMNEdge id="Flow_1w3680k_di" bpmnElement="Flow_1w3680k">
         <di:waypoint x="270" y="475" />
         <di:waypoint x="270" y="532" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04fxx9j_di" bpmnElement="Flow_04fxx9j">
+        <di:waypoint x="338" y="340" />
+        <di:waypoint x="358" y="340" />
+        <di:waypoint x="358" y="450" />
+        <di:waypoint x="295" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0az7c7m_di" bpmnElement="Flow_0az7c7m">
+        <di:waypoint x="380" y="158" />
+        <di:waypoint x="380" y="230" />
+        <di:waypoint x="288" y="230" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
Closes #140

### Proposed Changes

- [ ] Compensation Activity and Event now don't show `no-implicit-error`

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
