### PR TITLE
Fixed README Example Usage in the Node API

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,23 @@ const xmlStr = `
 
     // Output the linting reports (warnings/errors) to the console
     console.log(reports);
+
+    // {
+    //     'no-bpmndi': [
+    //     {
+    //         id: 'SequenceFlow_06kfaev',
+    //         message: 'Element is missing bpmndi',
+    //         category: 'error'
+    //     },
+    //     {
+    //         id: 'EndEvent_1fx9yp3',
+    //         message: 'Element is missing bpmndi',
+    //         category: 'error'
+    //     },
+    //     ........
+    //     ]
+    // }
+
 })();
 ```
 


### PR DESCRIPTION
- Refactored the BPMN linting code to use CommonJS syntax - (require) instead of ES6 imports as it is the default behavior when initializing a node project
- Introduced async/await within an IIFE to handle asynchronous XML parsing and linting in a synchronous-looking manner
- Initialized moddle instance for parsing BPMN XML data with BpmnModdle as the previous example caused issues due to lack of proper initialization.
- Linted BPMN definitions as even if the everything is set up correctly the default example causes the linter to crash.
- Enhanced the BPMN XML string with realistic process definitions, participants, lanes, and events for testing