### PR TITLE
Require Node@20

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [ 16 ]
+        node-version: [ 22 ]
 
     steps:
     - name: Checkout

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,9 +11,9 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Use Node.js ${{matrix.node-version}}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{matrix.node-version}}
         cache: 'npm'
@@ -33,9 +33,9 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Use Node.js ${{matrix.node-version}}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{matrix.node-version}}
         cache: 'npm'
@@ -53,9 +53,9 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Use Node.js ${{matrix.node-version}}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{matrix.node-version}}
         cache: 'npm'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to [bpmnlint](https://github.com/bpmn-io/bpmnlint) are docum
 
 ___Note:__ Yet to be released changes appear here._
 
+* `CHORE`: require Node@20
+
+### Breaking Changes
+
+* Node@20 is required to use this library.
+
 ## 10.3.1
 
 * `FIX`: correct false positive in `global` rule ([#139](https://github.com/bpmn-io/bpmnlint/issues/139))

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "strip-indent": "^3.0.0"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">= 20"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     }
   ],
   "engines": {
-    "node": ">= 16"
+    "node": ">= 20"
   },
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
### Proposed Changes

Update the requirement for node to Node@20. This is [soon the legacy node version](https://nodejs.org/en/about/previous-releases), so I think lifting up our requirements is fine.

At this stage this will simply indicate the incompatibility when upgrading `bpmnlint`. It will still _work_ on node@16, though we don't guarantee it anymore, going into the future.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->

----

Additional context:

* Internally, for development, we already use Node@20 for a long time
* Certain upgrades, such as [migrating from the now unmaintained `eslint@8` to `@9`](https://github.com/bpmn-io/bpmnlint/pull/148) require us also to upgrade to node@20