### PR TITLE
fix(no-bpmndi): handle missing `bpmnElement` on `BPMNEdge` or `BPMNShape`

### DIFF
--- a/rules/no-bpmndi.js
+++ b/rules/no-bpmndi.js
@@ -109,7 +109,7 @@ function getAllDiBpmnReferences(definitionsNode) {
 
       return diElements.map((element) => {
 
-        return element.bpmnElement.id;
+        return element.bpmnElement?.id;
       });
     })
   );

--- a/test/rules/no-bpmndi.mjs
+++ b/test/rules/no-bpmndi.mjs
@@ -56,6 +56,9 @@ RuleTester.verify('no-bpmndi', rule, {
     },
     {
       moddleElement: readModdle(__dirname + '/no-bpmndi/valid-message-flow.bpmn')
+    },
+    {
+      moddleElement: readModdle(__dirname + '/no-bpmndi/ignore-edge-without-bpmn-element.bpmn')
     }
   ],
   invalid: [

--- a/test/rules/no-bpmndi/ignore-edge-without-bpmn-element.bpmn
+++ b/test/rules/no-bpmndi/ignore-edge-without-bpmn-element.bpmn
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1k364re" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1iz3i5x" isExecutable="true"></bpmn:process>
+
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1">
+      <bpmndi:BPMNEdge id="Flow_0agwm11_di" bpmnElement="does-not-exist"></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
### Proposed Changes

Following #154, I've found another case where the `no-bpmndi` rule breaks. When a `BPMNEdge` or `BPMNShape` has a `bpmnElement` attribute which doesn't match to any element in the diagram it would crash the rule, leading to a `rule-error`:

```js
rule <no-bpmndi> failed with error:  TypeError: Cannot read properties of undefined (reading 'id')
    at /Users/marcoroth/Development/bpmnlint/rules/no-bpmndi.js:112:36
    at Array.map (<anonymous>)
    at /Users/marcoroth/Development/bpmnlint/rules/no-bpmndi.js:110:25
    at Array.map (<anonymous>)
    at getAllDiBpmnReferences (/Users/marcoroth/Development/bpmnlint/rules/no-bpmndi.js:106:37)
    at check (/Users/marcoroth/Development/bpmnlint/rules/no-bpmndi.js:28:30)
    at traverse.enter (/Users/marcoroth/Development/bpmnlint/lib/test-rule.js:70:30)
    at traverse (/Users/marcoroth/Development/bpmnlint/lib/traverse.js:18:33)
    at testRule (/Users/marcoroth/Development/bpmnlint/lib/test-rule.js:69:3)
    at Linter.applyRule (/Users/marcoroth/Development/bpmnlint/lib/linter.js:57:21)
```

This pull request adds a safe-navigator to make sure it wouldn't crash when it cannot find a matching  `bpmnElement` for a `BPMNEdge` or `BPMNShape`.

There is technically another similar potential issue when navigating `diagram.plane.planeElement` here:

https://github.com/bpmn-io/bpmnlint/blob/a201f2d909c2cc16c8ac2adf3be30ab324e5475c/rules/no-bpmndi.js#L108

Let me know if I should update that too, though I haven't encountered that in the diagrams I've been linting.

Reproduction script:

<details>
<summary>Show</summary>

```js
import { Linter } from 'bpmnlint'
import NodeResolver from 'bpmnlint/lib/resolver/node-resolver.js'
import BpmnModdle from 'bpmn-moddle'

const xml = `
<?xml version="1.0" encoding="UTF-8"?>
<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1k364re" targetNamespace="http://bpmn.io/schema/bpmn">
  <bpmn:process id="Process_1iz3i5x" isExecutable="true"></bpmn:process>

  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
    <bpmndi:BPMNPlane id="BPMNPlane_1">
      <bpmndi:BPMNEdge id="Flow_0agwm11_di" bpmnElement="does-not-exist"></bpmndi:BPMNEdge>
    </bpmndi:BPMNPlane>
  </bpmndi:BPMNDiagram>
</bpmn:definitions>
`

const config = {
  resolver: new NodeResolver(),
  config: {
    rules: {
      "no-bpmndi": "error"
    }
  }
}

const moddle = new BpmnModdle()
const linter = new Linter(config)
const { rootElement } = await moddle.fromXML(xml)

console.log(await linter.lint(rootElement))
```

</details>

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
