### PR TITLE
fix(no-overlapping-elements): skip when an element is missing `bounds`

### DIFF
--- a/rules/no-overlapping-elements.js
+++ b/rules/no-overlapping-elements.js
@@ -108,7 +108,15 @@ function checkElementsArray(elements, elementsToReport, diObjects) {
         continue;
       }
 
-      if (isCollision(diObjects.get(element).bounds, diObjects.get(element2).bounds)) {
+      const bounds1 = diObjects.get(element)?.bounds;
+      const bounds2 = diObjects.get(element2)?.bounds;
+
+      // ignore if an element doesn't have bounds
+      if (!bounds1 || !bounds2) {
+        continue;
+      }
+
+      if (isCollision(bounds1, bounds2)) {
         elementsToReport.add(element);
         elementsToReport.add(element2);
       }

--- a/test/rules/no-overlapping-elements.mjs
+++ b/test/rules/no-overlapping-elements.mjs
@@ -35,6 +35,9 @@ RuleTester.verify('no-overlapping-elements', rule, {
     },
     {
       moddleElement: readModdle(__dirname + '/no-overlapping-elements/ignore-missing-di.bpmn')
+    },
+    {
+      moddleElement: readModdle(__dirname + '/no-overlapping-elements/ignore-missing-bounds.bpmn')
     }
   ],
   invalid: [

--- a/test/rules/no-overlapping-elements/ignore-missing-bounds.bpmn
+++ b/test/rules/no-overlapping-elements/ignore-missing-bounds.bpmn
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:collaboration id="collaboration_675045400">
+    <bpmn:participant id="participant_882032013" name="Participant 1" />
+    <bpmn:participant id="participant_882032012" name="Participant 2" />
+  </bpmn:collaboration>
+</bpmn:definitions>


### PR DESCRIPTION
### Proposed Changes

I've been running into some cases where some elements in the diagram don't have matching `bounds` in the DI, which lead the `no-overlapping-elements`  rule crash with a `rule-error`:

```js
rule <no-overlapping-elements> failed with error:  TypeError: Cannot read properties of undefined (reading 'bounds')
    at checkElementsArray (/Users/marcoroth/Development/bpmnlint/rules/no-overlapping-elements.js:111:45)
    at /Users/marcoroth/Development/bpmnlint/rules/no-overlapping-elements.js:28:9
    at Array.forEach (<anonymous>)
    at check (/Users/marcoroth/Development/bpmnlint/rules/no-overlapping-elements.js:26:8)
    at traverse.enter (/Users/marcoroth/Development/bpmnlint/lib/test-rule.js:70:30)
    at traverse (/Users/marcoroth/Development/bpmnlint/lib/traverse.js:18:33)
    at testRule (/Users/marcoroth/Development/bpmnlint/lib/test-rule.js:69:3)
    at Linter.applyRule (/Users/marcoroth/Development/bpmnlint/lib/linter.js:57:21)
    at /Users/marcoroth/Development/bpmnlint/lib/linter.js:243:28
    at Array.forEach (<anonymous>)
```

This pull request adds a check to `continue` early when one of the two compared elements doesn't have matching `bounds`.

Reproduction script:

<details>
<summary>Show</summary>

```js
import { Linter } from 'bpmnlint'
import NodeResolver from 'bpmnlint/lib/resolver/node-resolver.js'
import BpmnModdle from 'bpmn-moddle'

const xml = `
  <?xml version="1.0" encoding="UTF-8"?>
  <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" targetNamespace="http://bpmn.io/schema/bpmn">
    <bpmn:collaboration id="collaboration_675045400">
      <bpmn:participant id="participant_882032013" name="Participant 1" />
      <bpmn:participant id="participant_882032012" name="Participant 2" />
    </bpmn:collaboration>
  </bpmn:definitions>
`

const config = {
  resolver: new NodeResolver(),
  config: {
    rules: {
      "no-overlapping-elements": "warn"
    }
  }
}

const moddle = new BpmnModdle()
const linter = new Linter(config)
const { rootElement } = await moddle.fromXML(xml)

console.log(await linter.lint(rootElement))

```
</details>


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
