### PR TITLE
chore: improve error message on missing rule hooks

### DIFF
--- a/lib/test-rule.js
+++ b/lib/test-rule.js
@@ -2,7 +2,8 @@ const traverse = require('./traverse');
 
 const {
   isArray,
-  isObject
+  isObject,
+  isFunction
 } = require('min-dash');
 
 
@@ -57,10 +58,12 @@ class Reporter {
 module.exports = function testRule({ moddleRoot, rule }) {
   const reporter = new Reporter({ rule, moddleRoot });
 
-  const check = rule.check;
+  const check = rule.check || {};
 
-  const enter = check && check.enter || check;
-  const leave = check && check.leave;
+  const leave = 'leave' in check ? check.leave : undefined;
+  const enter = 'enter' in check ? check.enter : (
+    isFunction(check) ? check : undefined
+  );
 
   if (!enter && !leave) {
     throw new Error('no check implemented');

--- a/test/spec/linter-spec.mjs
+++ b/test/spec/linter-spec.mjs
@@ -157,7 +157,7 @@ describe('linter', function() {
       expect(results).to.eql([
         {
           category: 'rule-error',
-          message: 'enter is not a function'
+          message: 'no check implemented'
         }
       ]);
     });


### PR DESCRIPTION
### Proposed Changes

We now clearly indicate that <enter> and <leave> are not provided, when an empty object is being returned as `check`.


Depends on https://github.com/bpmn-io/bpmnlint/pull/164 for :green_circle: CI.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
