### PR TITLE
Be able to configure meta-data with rules (and pass them to reports)

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -25,7 +25,7 @@ const testRule = require('./test-rule');
  * } } ResolvedRuleDefinition
  *
  * @typedef { import('./types.js').Report } Report
- * @typedef { Report & {
+ * @typedef { Report & Pick<RuleDefinition, 'meta'> & {
  *   category: ReportingCategory | RuleErrorCategory
  * } } AnnotatedReport
  *
@@ -111,6 +111,7 @@ Linter.prototype.applyRule = function applyRule(moddleRoot, ruleDefinition) {
     return reports.map(function(report) {
       return {
         ...report,
+        meta: rule.meta,
         category
       };
     });

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -29,8 +29,21 @@ const testRule = require('./test-rule');
  *   category: ReportingCategory | RuleErrorCategory
  * } } AnnotatedReport
  *
+ * @typedef { import('./types.js').TransformRuleFn } TransformRuleFn
+ *
  * @typedef { Record<string, AnnotatedReport[]> } LintResults
  */
+
+
+/**
+ * Transform a rule after it is loaded.
+ *
+ * @param { RuleDefinition } rule
+ * @param { { pkg: string, ruleName: string } } options
+ */
+const noopTransformRule = (rule, options) => {
+  return rule;
+};
 
 
 /**
@@ -51,14 +64,16 @@ const ruleErrorCategory = 'rule-error';
 /**
  * @param { {
  *   config?: Config,
- *   resolver: Resolver
+ *   resolver: Resolver,
+ *   transformRule?: TransformRuleFn
  * } } options
  */
 function Linter(options) {
 
   const {
     config = {},
-    resolver
+    resolver,
+    transformRule = noopTransformRule
   } = options || {};
 
   if (typeof resolver === 'undefined') {
@@ -67,6 +82,8 @@ function Linter(options) {
 
   this.config = config;
   this.resolver = resolver;
+
+  this.transformRule = transformRule;
 
   /**
    * @type { Record<string, RuleDefinition> }
@@ -156,7 +173,7 @@ Linter.prototype.resolveRule = function(name, config) {
       throw new Error(`unknown rule <${name}>`);
     }
 
-    const rule = this.cachedRules[id] = ruleFactory(config);
+    const rule = this.cachedRules[id] = this.transformRule(ruleFactory(config), { pkg, ruleName });
 
     return rule;
   });

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -68,6 +68,11 @@ export type Config = {
   rules?: RuleConfigs
 };
 
+export type TransformRuleFn = (
+  rule: RuleDefinition,
+  options: { pkg: string, ruleName: string }
+) => RuleDefinition;
+
 export type Report = {
   id?: string,
   path?: string[],

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -33,6 +33,11 @@ export type CheckDefinition = EnterFn | {
 };
 
 export type RuleDefinition = {
+  meta?: {
+    documentation?: {
+      url?: string
+    }
+  },
   check: CheckDefinition
 };
 

--- a/test/spec/linter-spec.mjs
+++ b/test/spec/linter-spec.mjs
@@ -949,8 +949,63 @@ describe('linter', function() {
 
   it('caching behavior');
 
+
+  describe('reporting', function() {
+
+    let moddleRoot;
+
+    const linter = new Linter({
+      resolver: fakeResolver()
+    });
+
+    const annotateRule = (rule, meta) => {
+
+      return {
+        ...rule,
+        meta
+      };
+    };
+
+    beforeEach(async function() {
+      const result = await readModdle(__dirname + '/diagram.bpmn');
+
+      moddleRoot = result.root;
+    });
+
+
+    it('should attach rule <meta> to report', function() {
+
+      // given
+      const meta = { foo: 'BAR' };
+
+      const rule = annotateRule(
+        createRule(fakeRule),
+        meta
+      );
+
+      // when
+      const results = linter.applyRule(
+        moddleRoot,
+        {
+          name: 'test-rule',
+          config: { },
+          rule,
+          category: 'error'
+        }
+      );
+
+      const expectedResult = buildFakeResults('error', null, meta);
+
+      // then
+      expect(results).to.eql(expectedResult);
+    });
+
+  });
+
 });
 
+
+// helpers //////////////
 
 function fakeResolver(cache = {}) {
   return {
@@ -963,7 +1018,6 @@ function fakeResolver(cache = {}) {
     }
   };
 }
-
 
 async function fakeAsyncRule() {
 
@@ -995,7 +1049,7 @@ function fakeRule(config = {}) {
 }
 
 
-function buildFakeResults(category, message) {
+function buildFakeResults(category, message, meta) {
   const results = [
     {
       id: 'sid-38422fae-e03e-43a3-bef4-bd33b32041b2',
@@ -1010,11 +1064,11 @@ function buildFakeResults(category, message) {
   return results.map((result) => {
     return {
       ...result,
-      category
+      category,
+      meta
     };
   });
 }
-
 
 function fakeEnterLeaveRule() {
 
@@ -1047,8 +1101,7 @@ function fakeEnterLeaveRule() {
   };
 }
 
-
-function buildFakeEnterLeaveResults(category, message) {
+function buildFakeEnterLeaveResults(category, message, meta) {
   const results = [
     {
       id: 'sid-38422fae-e03e-43a3-bef4-bd33b32041b2',
@@ -1063,7 +1116,8 @@ function buildFakeEnterLeaveResults(category, message) {
   return results.map((result) => {
     return {
       ...result,
-      category
+      category,
+      meta
     };
   });
 }


### PR DESCRIPTION
### Proposed Changes

As described in https://github.com/bpmn-io/bpmnlint/issues/18, this allows rule authors to configure `meta` in a rule. The meta-data will be passed along with reports so downstream integrators, can, i.e. ship custom documentation URLs with their rules (https://github.com/camunda/camunda-modeler/issues/4491).

#### Example rule (exposing a documentation URL)

```javascript

module.exports = function(config) {
  return {
    meta: {
      documentation: {
        url: 'https://github.com/bpmn-io/bpmnlint'
      }
    },
    check: (node, reporter) => {
      ...
    }
  };
};
```

#### What's inside this PR

This PR is comprised in two parts:

* https://github.com/bpmn-io/bpmnlint/commit/038a2cbfbfb0bf3b92a98be1c78d8c03bf0ea0e5 adds `meta` support
* https://github.com/bpmn-io/bpmnlint/commit/95be026251554f0392363a2aed25bf4fb19bb868 adds a transform hook that allows integrators to attach and/or modify existing rules (whereas the purpose is on modifying meta-data, i.e. overriding documentation URLs, or attaching them)


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->


------


Closes https://github.com/bpmn-io/bpmnlint/issues/18

Depends on #163 