### PR TITLE
Add documentation URL to built-in rules

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -70,9 +70,14 @@ function verify(ruleName, rule, testCases) {
             ];
           }
 
+          const {
+            meta
+          } = await linter.resolveRule(name, config);
+
           const expectedResults = report.map(report => {
             return {
               ...report,
+              meta,
               category: 'error'
             };
           });

--- a/rules/ad-hoc-sub-process.js
+++ b/rules/ad-hoc-sub-process.js
@@ -3,6 +3,11 @@ const {
   isAny
 } = require('bpmnlint-utils');
 
+const {
+  annotateRule
+} = require('./helper');
+
+
 /**
  * A rule that ensures that an Ad Hoc Sub Process is valid according to the BPMN spec:
  *
@@ -40,8 +45,8 @@ module.exports = function() {
     });
   }
 
-  return {
+  return annotateRule('ad-hoc-sub-process', {
     check
-  };
+  });
 
 };

--- a/rules/conditional-flows.js
+++ b/rules/conditional-flows.js
@@ -1,3 +1,8 @@
+const {
+  annotateRule
+} = require('./helper');
+
+
 /**
  * A rule that checks that sequence flows outgoing from a
  * conditional forking gateway or activity are
@@ -27,9 +32,9 @@ module.exports = function() {
     });
   }
 
-  return {
+  return annotateRule('conditional-flows', {
     check
-  };
+  });
 
 };
 

--- a/rules/end-event-required.js
+++ b/rules/end-event-required.js
@@ -3,6 +3,10 @@ const {
   isAny
 } = require('bpmnlint-utils');
 
+const {
+  annotateRule
+} = require('./helper');
+
 
 /**
  * A rule that checks the presence of an end event per scope.
@@ -35,5 +39,7 @@ module.exports = function() {
     }
   }
 
-  return { check };
+  return annotateRule('end-event-required', {
+    check
+  });
 };

--- a/rules/event-sub-process-typed-start-event.js
+++ b/rules/event-sub-process-typed-start-event.js
@@ -2,6 +2,11 @@ const {
   is
 } = require('bpmnlint-utils');
 
+const {
+  annotateRule
+} = require('./helper');
+
+
 /**
  * A rule that checks that start events inside an event sub-process
  * are typed.
@@ -32,8 +37,8 @@ module.exports = function() {
     });
   }
 
-  return {
+  return annotateRule('event-sub-process-typed-start-event', {
     check
-  };
+  });
 
 };

--- a/rules/fake-join.js
+++ b/rules/fake-join.js
@@ -2,6 +2,11 @@ const {
   isAny
 } = require('bpmnlint-utils');
 
+const {
+  annotateRule
+} = require('./helper');
+
+
 /**
  * A rule that checks that no fake join is modeled by attempting
  * to give a task or event join semantics.
@@ -29,8 +34,8 @@ module.exports = function() {
     }
   }
 
-  return {
+  return annotateRule('fake-join', {
     check
-  };
+  });
 
 };

--- a/rules/global.js
+++ b/rules/global.js
@@ -3,6 +3,10 @@ const {
   isAny
 } = require('bpmnlint-utils');
 
+const {
+  annotateRule
+} = require('./helper');
+
 
 /**
  * A rule that verifies that global elements are properly used.
@@ -50,9 +54,9 @@ module.exports = function() {
 
   }
 
-  return {
+  return annotateRule('global', {
     check
-  };
+  });
 
   // helpers /////////////////////////////
 

--- a/rules/helper.js
+++ b/rules/helper.js
@@ -6,6 +6,7 @@ const {
  * @typedef { import('../lib/types.js').ModdleElement } ModdleElement
  *
  * @typedef { import('../lib/types.js').RuleFactory } RuleFactory
+ * @typedef { import('../lib/types.js').RuleDefinition } RuleDefinition
  */
 
 
@@ -16,7 +17,7 @@ const {
  *
  * @return { RuleFactory } ruleFactory
  */
-function disallowNodeType(type) {
+function disallowNodeType(type, ruleName) {
 
   /**
    * @type { RuleFactory }
@@ -30,9 +31,9 @@ function disallowNodeType(type) {
       }
     }
 
-    return {
+    return annotateRule(ruleName, {
       check
-    };
+    });
 
   };
 
@@ -68,3 +69,40 @@ function findParent(node, type) {
 }
 
 module.exports.findParent = findParent;
+
+
+const documentationBaseUrl = 'https://github.com/bpmn-io/bpmnlint/blob/main/docs/rules';
+
+/**
+ * Annotate a rule with core information, such as the documentation url.
+ *
+ * @param {string} ruleName
+ * @param {RuleDefinition} options
+ *
+ * @return {RuleDefinition}
+ */
+function annotateRule(ruleName, options) {
+
+  const {
+    meta: {
+      documentation = {},
+      ...restMeta
+    } = {},
+    ...restOptions
+  } = options;
+
+  const documentationUrl = `${documentationBaseUrl}/${ruleName}.md`;
+
+  return {
+    meta: {
+      documentation: {
+        url: documentationUrl,
+        ...documentation
+      },
+      ...restMeta
+    },
+    ...restOptions
+  };
+}
+
+module.exports.annotateRule = annotateRule;

--- a/rules/label-required.js
+++ b/rules/label-required.js
@@ -3,6 +3,10 @@ const {
   isAny
 } = require('bpmnlint-utils');
 
+const {
+  annotateRule
+} = require('./helper');
+
 
 /**
  * A rule that checks the presence of a label.
@@ -53,7 +57,9 @@ module.exports = function() {
     }
   }
 
-  return { check };
+  return annotateRule('label-required', {
+    check
+  });
 };
 
 

--- a/rules/link-event.js
+++ b/rules/link-event.js
@@ -6,6 +6,10 @@ const {
   is
 } = require('bpmnlint-utils');
 
+const {
+  annotateRule
+} = require('./helper');
+
 
 /**
  * A rule that verifies that link events are properly used.
@@ -71,9 +75,9 @@ module.exports = function() {
 
   }
 
-  return {
+  return annotateRule('link-event', {
     check
-  };
+  });
 };
 
 

--- a/rules/no-bpmndi.js
+++ b/rules/no-bpmndi.js
@@ -6,9 +6,14 @@ const {
   flatten
 } = require('min-dash');
 
+const {
+  annotateRule
+} = require('./helper');
+
 /**
  * @typedef { import('../lib/types.js').ModdleElement } ModdleElement
  */
+
 
 /**
  * A rule that checks that there is no BPMNDI information missing for elements,
@@ -41,9 +46,9 @@ module.exports = function() {
     });
   }
 
-  return {
+  return annotateRule('no-bpmndi', {
     check
-  };
+  });
 
 };
 

--- a/rules/no-complex-gateway.js
+++ b/rules/no-complex-gateway.js
@@ -1,3 +1,3 @@
 const disallowNodeType = require('./helper').disallowNodeType;
 
-module.exports = disallowNodeType('bpmn:ComplexGateway');
+module.exports = disallowNodeType('bpmn:ComplexGateway', 'no-complex-gateway');

--- a/rules/no-disconnected.js
+++ b/rules/no-disconnected.js
@@ -3,6 +3,10 @@ const {
   is
 } = require('bpmnlint-utils');
 
+const {
+  annotateRule
+} = require('./helper');
+
 
 /**
  * A rule that verifies that there exists no disconnected
@@ -38,9 +42,9 @@ module.exports = function() {
     }
   }
 
-  return {
+  return annotateRule('no-disconnected', {
     check
-  };
+  });
 };
 
 

--- a/rules/no-duplicate-sequence-flows.js
+++ b/rules/no-duplicate-sequence-flows.js
@@ -2,6 +2,11 @@ const {
   is
 } = require('bpmnlint-utils');
 
+const {
+  annotateRule
+} = require('./helper');
+
+
 /**
  * A rule that verifies that there are no disconnected
  * flow elements, i.e. elements without incoming or outgoing sequence flows.
@@ -45,9 +50,9 @@ module.exports = function() {
     }
   }
 
-  return {
+  return annotateRule('no-duplicate-sequence-flows', {
     check
-  };
+  });
 
 };
 

--- a/rules/no-gateway-join-fork.js
+++ b/rules/no-gateway-join-fork.js
@@ -2,6 +2,10 @@ const {
   is
 } = require('bpmnlint-utils');
 
+const {
+  annotateRule
+} = require('./helper');
+
 
 /**
  * A rule that checks, whether a gateway forks and joins
@@ -25,8 +29,8 @@ module.exports = function() {
     }
   }
 
-  return {
+  return annotateRule('no-gateway-fork-join', {
     check
-  };
+  });
 
 };

--- a/rules/no-implicit-end.js
+++ b/rules/no-implicit-end.js
@@ -4,8 +4,10 @@ const {
 } = require('bpmnlint-utils');
 
 const {
-  findParent
+  findParent,
+  annotateRule
 } = require('./helper');
+
 
 /**
  * A rule that checks that an element is not an implicit end (token sink).
@@ -87,5 +89,7 @@ module.exports = function() {
     }
   }
 
-  return { check };
+  return annotateRule('no-implicit-end', {
+    check
+  });
 };

--- a/rules/no-implicit-split.js
+++ b/rules/no-implicit-split.js
@@ -2,6 +2,10 @@ const {
   isAny
 } = require('bpmnlint-utils');
 
+const {
+  annotateRule
+} = require('./helper');
+
 
 /**
  * A rule that checks that no implicit split is modeled
@@ -34,9 +38,9 @@ module.exports = function() {
     }
   }
 
-  return {
+  return annotateRule('no-implicit-split', {
     check
-  };
+  });
 
 };
 

--- a/rules/no-implicit-start.js
+++ b/rules/no-implicit-start.js
@@ -3,6 +3,9 @@ const {
   isAny
 } = require('bpmnlint-utils');
 
+const {
+  annotateRule
+} = require('./helper');
 
 /**
  * A rule that checks that an element is not an implicit start (token spawn).
@@ -52,5 +55,7 @@ module.exports = function() {
     }
   }
 
-  return { check };
+  return annotateRule('no-implicit-start', {
+    check
+  });
 };

--- a/rules/no-inclusive-gateway.js
+++ b/rules/no-inclusive-gateway.js
@@ -1,3 +1,3 @@
 const disallowNodeType = require('./helper').disallowNodeType;
 
-module.exports = disallowNodeType('bpmn:InclusiveGateway');
+module.exports = disallowNodeType('bpmn:InclusiveGateway', 'no-inclusive-gateway');

--- a/rules/no-overlapping-elements.js
+++ b/rules/no-overlapping-elements.js
@@ -2,6 +2,10 @@ const {
   is
 } = require('bpmnlint-utils');
 
+const {
+  annotateRule
+} = require('./helper');
+
 
 /**
  * Rule that checks if two elements overlap except:
@@ -47,9 +51,9 @@ module.exports = function() {
     elementsOutsideToReport.forEach(element => reporter.report(element.id, 'Element is outside of parent boundary'));
   }
 
-  return {
-    check: check
-  };
+  return annotateRule('no-overlapping-elements', {
+    check
+  });
 };
 
 // helpers /////////////////

--- a/rules/single-blank-start-event.js
+++ b/rules/single-blank-start-event.js
@@ -2,6 +2,11 @@ const {
   is
 } = require('bpmnlint-utils');
 
+const {
+  annotateRule
+} = require('./helper');
+
+
 /**
  * A rule that checks whether not more than one blank start event
  * exists per scope.
@@ -36,8 +41,8 @@ module.exports = function() {
     }
   }
 
-  return {
+  return annotateRule('single-blank-start-event', {
     check
-  };
+  });
 
 };

--- a/rules/single-event-definition.js
+++ b/rules/single-event-definition.js
@@ -2,6 +2,10 @@ const {
   is
 } = require('bpmnlint-utils');
 
+const {
+  annotateRule
+} = require('./helper');
+
 
 /**
  * A rule that verifies that an event contains maximum one event definition.
@@ -23,8 +27,8 @@ module.exports = function() {
     }
   }
 
-  return {
+  return annotateRule('single-event-definition', {
     check
-  };
+  });
 
 };

--- a/rules/start-event-required.js
+++ b/rules/start-event-required.js
@@ -3,6 +3,10 @@ const {
   isAny
 } = require('bpmnlint-utils');
 
+const {
+  annotateRule
+} = require('./helper');
+
 
 /**
  * A rule that checks for the presence of a start event per scope.
@@ -35,5 +39,7 @@ module.exports = function() {
     }
   }
 
-  return { check };
+  return annotateRule('start-event-required', {
+    check
+  });
 };

--- a/rules/sub-process-blank-start-event.js
+++ b/rules/sub-process-blank-start-event.js
@@ -2,6 +2,10 @@ const {
   is
 } = require('bpmnlint-utils');
 
+const {
+  annotateRule
+} = require('./helper');
+
 
 /**
  * A rule that checks that start events inside a normal sub-processes
@@ -33,8 +37,8 @@ module.exports = function() {
     });
   }
 
-  return {
+  return annotateRule('sub-process-blank-start-event', {
     check
-  };
+  });
 
 };

--- a/rules/superfluous-gateway.js
+++ b/rules/superfluous-gateway.js
@@ -2,6 +2,11 @@ const {
   is
 } = require('bpmnlint-utils');
 
+const {
+  annotateRule
+} = require('./helper');
+
+
 /**
  * A rule that checks, whether a gateway has only one source and target.
  *
@@ -25,8 +30,8 @@ module.exports = function() {
     }
   }
 
-  return {
+  return annotateRule('superfluous-gateway', {
     check
-  };
+  });
 
 };

--- a/rules/superfluous-termination.js
+++ b/rules/superfluous-termination.js
@@ -3,6 +3,11 @@ const {
   isAny
 } = require('bpmnlint-utils');
 
+const {
+  annotateRule
+} = require('./helper');
+
+
 /**
  * A rule that checks, whether a gateway has only one source and target.
  *
@@ -45,9 +50,9 @@ module.exports = function() {
     }
   }
 
-  return {
+  return annotateRule('superfluous-termination', {
     check
-  };
+  });
 
 };
 

--- a/test/integration/bundling/test/app.rollup.expected.js
+++ b/test/integration/bundling/test/app.rollup.expected.js
@@ -41,7 +41,7 @@
    *
    * @return {Boolean}
    */
-  function is$3(node, type) {
+  function is$4(node, type) {
 
     if (type.indexOf(':') === -1) {
       type = 'bpmn:' + type;
@@ -64,22 +64,137 @@
    */
   function isAny$3(node, types) {
     return types.some(function(type) {
-      return is$3(node, type);
+      return is$4(node, type);
     });
   }
 
   var index_esm = /*#__PURE__*/Object.freeze({
     __proto__: null,
-    is: is$3,
+    is: is$4,
     isAny: isAny$3
   });
 
   var require$$0 = /*@__PURE__*/getAugmentedNamespace(index_esm);
 
+  var helper = {};
+
+  const {
+    is: is$3
+  } = require$$0;
+
+  /**
+   * @typedef { import('../lib/types.js').ModdleElement } ModdleElement
+   *
+   * @typedef { import('../lib/types.js').RuleFactory } RuleFactory
+   * @typedef { import('../lib/types.js').RuleDefinition } RuleDefinition
+   */
+
+
+  /**
+   * Create a checker that disallows the given element type.
+   *
+   * @param { string } type
+   *
+   * @return { RuleFactory } ruleFactory
+   */
+  function disallowNodeType(type, ruleName) {
+
+    /**
+     * @type { RuleFactory }
+     */
+    return function() {
+
+      function check(node, reporter) {
+
+        if (is$3(node, type)) {
+          reporter.report(node.id, 'Element has disallowed type <' + type + '>');
+        }
+      }
+
+      return annotateRule$3(ruleName, {
+        check
+      });
+
+    };
+
+  }
+
+  helper.disallowNodeType = disallowNodeType;
+
+
+  /**
+   * Find a parent for the given element
+   *
+   * @param { ModdleElement } node
+   * @param { string } type
+   *
+   * @return { ModdleElement } element
+   */
+  function findParent(node, type) {
+    if (!node) {
+      return null;
+    }
+
+    const parent = node.$parent;
+
+    if (!parent) {
+      return node;
+    }
+
+    if (is$3(parent, type)) {
+      return parent;
+    }
+
+    return findParent(parent, type);
+  }
+
+  helper.findParent = findParent;
+
+
+  const documentationBaseUrl = 'https://github.com/bpmn-io/bpmnlint/blob/main/docs/rules';
+
+  /**
+   * Annotate a rule with core information, such as the documentation url.
+   *
+   * @param {string} ruleName
+   * @param {RuleDefinition} options
+   *
+   * @return {RuleDefinition}
+   */
+  function annotateRule$3(ruleName, options) {
+
+    const {
+      meta: {
+        documentation = {},
+        ...restMeta
+      } = {},
+      ...restOptions
+    } = options;
+
+    const documentationUrl = `${documentationBaseUrl}/${ruleName}.md`;
+
+    return {
+      meta: {
+        documentation: {
+          url: documentationUrl,
+          ...documentation
+        },
+        ...restMeta
+      },
+      ...restOptions
+    };
+  }
+
+  helper.annotateRule = annotateRule$3;
+
   const {
     is: is$2,
     isAny: isAny$2
   } = require$$0;
+
+  const {
+    annotateRule: annotateRule$2
+  } = helper;
 
 
   /**
@@ -131,7 +246,9 @@
       }
     }
 
-    return { check };
+    return annotateRule$2('label-required', {
+      check
+    });
   };
 
 
@@ -153,6 +270,10 @@
     is: is$1,
     isAny: isAny$1
   } = require$$0;
+
+  const {
+    annotateRule: annotateRule$1
+  } = helper;
 
 
   /**
@@ -186,7 +307,9 @@
       }
     }
 
-    return { check };
+    return annotateRule$1('start-event-required', {
+      check
+    });
   };
 
   var rule_1 = /*@__PURE__*/getDefaultExportFromCjs(startEventRequired);
@@ -195,6 +318,10 @@
     is,
     isAny
   } = require$$0;
+
+  const {
+    annotateRule
+  } = helper;
 
 
   /**
@@ -228,7 +355,9 @@
       }
     }
 
-    return { check };
+    return annotateRule('end-event-required', {
+      check
+    });
   };
 
   var rule_2 = /*@__PURE__*/getDefaultExportFromCjs(endEventRequired);

--- a/test/integration/bundling/test/app.webpack.expected.js
+++ b/test/integration/bundling/test/app.webpack.expected.js
@@ -79,6 +79,10 @@ const {
   isAny
 } = __webpack_require__(/*! bpmnlint-utils */ "./node_modules/bpmnlint-utils/dist/index.esm.js");
 
+const {
+  annotateRule
+} = __webpack_require__(/*! ./helper */ "./node_modules/bpmnlint/rules/helper.js");
+
 
 /**
  * A rule that checks the presence of an end event per scope.
@@ -111,9 +115,128 @@ module.exports = function() {
     }
   }
 
-  return { check };
+  return annotateRule('end-event-required', {
+    check
+  });
 };
 
+
+/***/ }),
+
+/***/ "./node_modules/bpmnlint/rules/helper.js":
+/*!***********************************************!*\
+  !*** ./node_modules/bpmnlint/rules/helper.js ***!
+  \***********************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+const {
+  is
+} = __webpack_require__(/*! bpmnlint-utils */ "./node_modules/bpmnlint-utils/dist/index.esm.js");
+
+/**
+ * @typedef { import('../lib/types.js').ModdleElement } ModdleElement
+ *
+ * @typedef { import('../lib/types.js').RuleFactory } RuleFactory
+ * @typedef { import('../lib/types.js').RuleDefinition } RuleDefinition
+ */
+
+
+/**
+ * Create a checker that disallows the given element type.
+ *
+ * @param { string } type
+ *
+ * @return { RuleFactory } ruleFactory
+ */
+function disallowNodeType(type, ruleName) {
+
+  /**
+   * @type { RuleFactory }
+   */
+  return function() {
+
+    function check(node, reporter) {
+
+      if (is(node, type)) {
+        reporter.report(node.id, 'Element has disallowed type <' + type + '>');
+      }
+    }
+
+    return annotateRule(ruleName, {
+      check
+    });
+
+  };
+
+}
+
+module.exports.disallowNodeType = disallowNodeType;
+
+
+/**
+ * Find a parent for the given element
+ *
+ * @param { ModdleElement } node
+ * @param { string } type
+ *
+ * @return { ModdleElement } element
+ */
+function findParent(node, type) {
+  if (!node) {
+    return null;
+  }
+
+  const parent = node.$parent;
+
+  if (!parent) {
+    return node;
+  }
+
+  if (is(parent, type)) {
+    return parent;
+  }
+
+  return findParent(parent, type);
+}
+
+module.exports.findParent = findParent;
+
+
+const documentationBaseUrl = 'https://github.com/bpmn-io/bpmnlint/blob/main/docs/rules';
+
+/**
+ * Annotate a rule with core information, such as the documentation url.
+ *
+ * @param {string} ruleName
+ * @param {RuleDefinition} options
+ *
+ * @return {RuleDefinition}
+ */
+function annotateRule(ruleName, options) {
+
+  const {
+    meta: {
+      documentation = {},
+      ...restMeta
+    } = {},
+    ...restOptions
+  } = options;
+
+  const documentationUrl = `${documentationBaseUrl}/${ruleName}.md`;
+
+  return {
+    meta: {
+      documentation: {
+        url: documentationUrl,
+        ...documentation
+      },
+      ...restMeta
+    },
+    ...restOptions
+  };
+}
+
+module.exports.annotateRule = annotateRule;
 
 /***/ }),
 
@@ -127,6 +250,10 @@ const {
   is,
   isAny
 } = __webpack_require__(/*! bpmnlint-utils */ "./node_modules/bpmnlint-utils/dist/index.esm.js");
+
+const {
+  annotateRule
+} = __webpack_require__(/*! ./helper */ "./node_modules/bpmnlint/rules/helper.js");
 
 
 /**
@@ -178,7 +305,9 @@ module.exports = function() {
     }
   }
 
-  return { check };
+  return annotateRule('label-required', {
+    check
+  });
 };
 
 
@@ -206,6 +335,10 @@ const {
   is,
   isAny
 } = __webpack_require__(/*! bpmnlint-utils */ "./node_modules/bpmnlint-utils/dist/index.esm.js");
+
+const {
+  annotateRule
+} = __webpack_require__(/*! ./helper */ "./node_modules/bpmnlint/rules/helper.js");
 
 
 /**
@@ -239,7 +372,9 @@ module.exports = function() {
     }
   }
 
-  return { check };
+  return annotateRule('start-event-required', {
+    check
+  });
 };
 
 

--- a/test/rules/link-event.mjs
+++ b/test/rules/link-event.mjs
@@ -28,53 +28,43 @@ RuleTester.verify('link-event', rule, {
       report: [
         {
           'id': 'THROW_NO_NAME',
-          'message': 'Link event is missing name',
-          'category': 'error'
+          'message': 'Link event is missing name'
         },
         {
           'id': 'CATCH_NO_NAME',
-          'message': 'Link event is missing name',
-          'category': 'error'
+          'message': 'Link event is missing name'
         },
         {
           'id': 'NO_CATCH',
-          'message': 'Link catch event with name <NO_CATCH> missing in scope',
-          'category': 'error'
+          'message': 'Link catch event with name <NO_CATCH> missing in scope'
         },
         {
           'id': 'NO_THROW',
-          'message': 'Link throw event with name <NO_THROW> missing in scope',
-          'category': 'error'
+          'message': 'Link throw event with name <NO_THROW> missing in scope'
         },
         {
           'id': 'SCOPE_BOUNDARY_THROW',
-          'message': 'Link catch event with name <SCOPE_BOUNDARY> missing in scope',
-          'category': 'error'
+          'message': 'Link catch event with name <SCOPE_BOUNDARY> missing in scope'
         },
         {
           'id': 'DUPLICATE_NAME_THROW_1',
-          'message': 'Duplicate link throw event with name <DUPLICATE_NAME> in scope',
-          'category': 'error'
+          'message': 'Duplicate link throw event with name <DUPLICATE_NAME> in scope'
         },
         {
           'id': 'DUPLICATE_NAME_THROW_2',
-          'message': 'Duplicate link throw event with name <DUPLICATE_NAME> in scope',
-          'category': 'error'
+          'message': 'Duplicate link throw event with name <DUPLICATE_NAME> in scope'
         },
         {
           'id': 'DUPLICATE_NAME_CATCH_1',
-          'message': 'Duplicate link catch event with name <DUPLICATE_NAME> in scope',
-          'category': 'error'
+          'message': 'Duplicate link catch event with name <DUPLICATE_NAME> in scope'
         },
         {
           'id': 'DUPLICATE_NAME_CATCH_2',
-          'message': 'Duplicate link catch event with name <DUPLICATE_NAME> in scope',
-          'category': 'error'
+          'message': 'Duplicate link catch event with name <DUPLICATE_NAME> in scope'
         },
         {
           'id': 'SCOPE_BOUNDARY_CATCH',
-          'message': 'Link throw event with name <SCOPE_BOUNDARY> missing in scope',
-          'category': 'error'
+          'message': 'Link throw event with name <SCOPE_BOUNDARY> missing in scope'
         }
       ]
     }

--- a/test/spec/testers/rule-tester-spec.mjs
+++ b/test/spec/testers/rule-tester-spec.mjs
@@ -149,6 +149,34 @@ describe('rule-tester', function() {
 
     });
 
+
+    describe('with <meta>', function() {
+
+      const meta = { foo: 1 };
+
+      verify('with-local-config', (config) => {
+        return {
+          check: (node, reporter) => {
+            reporter.report(node.get('id'), config);
+          },
+          meta
+        };
+      }, {
+        valid: [],
+        invalid: [
+          {
+            name: 'with config',
+            config: 'foo',
+            moddleElement: createModdle('<bpmn:Task id="Task_1" />', 'bpmn:Task'),
+            report: {
+              id: 'Task_1',
+              message: 'foo'
+            }
+          }
+        ]
+      });
+
+    });
   });
 
 });


### PR DESCRIPTION
### Proposed Changes

Builds on top of #165 to provide documentation URL with built-in rules.

#### What's inside

* FIX: rule tester did not properly validate `meta` - https://github.com/bpmn-io/bpmnlint/commit/3041995b30255a6ad535d00b105f28161d827307
* FEAT: attach project documentation URL to built-in rules - https://github.com/bpmn-io/bpmnlint/commit/a4c73092d4a0d059170db47da1ce2ff7e34fd60c

Closes https://github.com/bpmn-io/bpmnlint/issues/166

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
