### PR TITLE
Verify resolution of local plug-in + rules

### DIFF
--- a/test/integration/cli-spec.mjs
+++ b/test/integration/cli-spec.mjs
@@ -220,6 +220,35 @@ describe('cli', function() {
   });
 
 
+  describe('should resolve plug-in sources from working directory', function() {
+
+    before(function() {
+
+      this.timeout(100000);
+
+      return exec('install-local', [], __dirname + '/cli/local-rules');
+    });
+
+
+    verify({
+      cmd: [ 'bpmnlint', 'diagram.bpmn' ],
+      cwd: __dirname + '/cli/local-rules',
+      expect: {
+        code: 1,
+        stderr: EMPTY,
+        stdout: `
+
+          ${diagramPath('local-rules/diagram.bpmn')}
+            END  error  Element has non-sense label <bar>  local/no-label-bar
+
+          ✖ 1 problem (1 error, 0 warnings)
+        `
+      }
+    });
+
+  });
+
+
   describe('should handle namespaced packages', function() {
 
     before(function() {

--- a/test/integration/cli/local-rules/.bpmnlintrc
+++ b/test/integration/cli/local-rules/.bpmnlintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "plugin:local/recommended"
+}

--- a/test/integration/cli/local-rules/diagram.bpmn
+++ b/test/integration/cli/local-rules/diagram.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="DEFINITIONS_1" targetNamespace="http://bpmn.io/bpmn" exporter="bpmn-js (https://demo.bpmn.io)" exporterVersion="12.0.0">
+  <collaboration id="COLLABORATION">
+    <participant id="PARTICIPANT_A" name="A" processRef="PROCESS_1" />
+    <participant id="PARTICIPANT_B" name="B" />
+    <messageFlow id="MESSAGE_FLOW" sourceRef="PARTICIPANT_A" targetRef="PARTICIPANT_B" />
+  </collaboration>
+  <process id="PROCESS_1" isExecutable="false">
+    <endEvent id="END" name="bar">
+      <incoming>FLOW_1</incoming>
+    </endEvent>
+    <startEvent id="START">
+      <outgoing>FLOW_1</outgoing>
+    </startEvent>
+    <sequenceFlow id="FLOW_1" sourceRef="START" targetRef="END" />
+  </process>
+  <bpmndi:BPMNDiagram id="BpmnDiagram_1">
+    <bpmndi:BPMNPlane id="BpmnPlane_1" bpmnElement="COLLABORATION">
+      <bpmndi:BPMNShape id="PARTICIPANT_A_di" bpmnElement="PARTICIPANT_A">
+        <omgdc:Bounds x="177" y="115" width="446" height="138" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="END_di" bpmnElement="END">
+        <omgdc:Bounds x="442" y="156" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="450" y="199" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="START_di" bpmnElement="START">
+        <omgdc:Bounds x="261" y="156" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="267" y="199" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="FLOW_1_di" bpmnElement="FLOW_1">
+        <omgdi:waypoint x="297" y="174" />
+        <omgdi:waypoint x="442" y="174" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="PARTICIPANT_B_di" bpmnElement="PARTICIPANT_B">
+        <omgdc:Bounds x="169" y="328" width="453" height="104" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="MESSAGE_FLOW_di" bpmnElement="MESSAGE_FLOW">
+        <omgdi:waypoint x="400" y="253" />
+        <omgdi:waypoint x="400" y="328" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/test/integration/cli/local-rules/lib/bpmnlint-plugin/index.js
+++ b/test/integration/cli/local-rules/lib/bpmnlint-plugin/index.js
@@ -1,0 +1,11 @@
+module.exports = {
+  configs: {
+    recommended: {
+      extends: 'bpmnlint:recommended',
+      rules: {
+        'no-label-bar': 'error',
+        'bpmnlint/label-required': 'off'
+      }
+    }
+  }
+};

--- a/test/integration/cli/local-rules/lib/bpmnlint-plugin/package.json
+++ b/test/integration/cli/local-rules/lib/bpmnlint-plugin/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "bpmnlint-plugin-local",
+  "version": "0.0.0",
+  "description": "Local bpmnlint rules",
+  "main": "index.js"
+}

--- a/test/integration/cli/local-rules/lib/bpmnlint-plugin/rules/no-label-bar.js
+++ b/test/integration/cli/local-rules/lib/bpmnlint-plugin/rules/no-label-bar.js
@@ -1,0 +1,15 @@
+/**
+ * Rule that reports bar labels.
+ */
+module.exports = function() {
+
+  function check(node, reporter) {
+    if (/^bar/.test(node.name || '')) {
+      reporter.report(node.id, 'Element has non-sense label <' + node.name + '>');
+    }
+  }
+
+  return {
+    check: check
+  };
+};

--- a/test/integration/cli/local-rules/package.json
+++ b/test/integration/cli/local-rules/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "local-rules",
+  "version": "0.0.0",
+  "description": "An application that provides local rules",
+  "main": "index.js",
+  "dependencies": {
+    "bpmnlint": "file:../../../..",
+    "bpmnlint-plugin-local": "file:./lib/bpmnlint-plugin"
+  }
+}


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/bpmn-io/bpmnlint/issues/81, this PR ensures there is a tested scenario available that shows how rules can be provided locally as part of an application. The solution is straight forward:

* Develop your rules in a sub-directory of your application, as if it was a bpmnlint plug-in
* Link (alias) the folder in your main application package, i.e. call it `bpmnlint-plugin-local`
* Reference the plug-in as `local` in wherever places you need
* :moneybag: 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
