### PR TITLE
Rework warning on elements that should not be used

### DIFF
--- a/rules/helper.js
+++ b/rules/helper.js
@@ -17,7 +17,7 @@ const {
  *
  * @return { RuleFactory } ruleFactory
  */
-function disallowNodeType(type, ruleName) {
+function checkDiscouragedNodeType(type, ruleName) {
 
   /**
    * @type { RuleFactory }
@@ -27,7 +27,7 @@ function disallowNodeType(type, ruleName) {
     function check(node, reporter) {
 
       if (is(node, type)) {
-        reporter.report(node.id, 'Element has disallowed type <' + type + '>');
+        reporter.report(node.id, 'Element type <' + type + '> is discouraged');
       }
     }
 
@@ -39,7 +39,7 @@ function disallowNodeType(type, ruleName) {
 
 }
 
-module.exports.disallowNodeType = disallowNodeType;
+module.exports.checkDiscouragedNodeType = checkDiscouragedNodeType;
 
 
 /**

--- a/rules/no-complex-gateway.js
+++ b/rules/no-complex-gateway.js
@@ -1,3 +1,3 @@
-const disallowNodeType = require('./helper').disallowNodeType;
+const checkDiscouragedNodeType = require('./helper').checkDiscouragedNodeType;
 
-module.exports = disallowNodeType('bpmn:ComplexGateway', 'no-complex-gateway');
+module.exports = checkDiscouragedNodeType('bpmn:ComplexGateway', 'no-complex-gateway');

--- a/rules/no-inclusive-gateway.js
+++ b/rules/no-inclusive-gateway.js
@@ -1,3 +1,3 @@
-const disallowNodeType = require('./helper').disallowNodeType;
+const checkDiscouragedNodeType = require('./helper').checkDiscouragedNodeType;
 
-module.exports = disallowNodeType('bpmn:InclusiveGateway', 'no-inclusive-gateway');
+module.exports = checkDiscouragedNodeType('bpmn:InclusiveGateway', 'no-inclusive-gateway');

--- a/test/integration/bundling/test/app.rollup.expected.js
+++ b/test/integration/bundling/test/app.rollup.expected.js
@@ -97,7 +97,7 @@
    *
    * @return { RuleFactory } ruleFactory
    */
-  function disallowNodeType(type, ruleName) {
+  function checkDiscouragedNodeType(type, ruleName) {
 
     /**
      * @type { RuleFactory }
@@ -107,7 +107,7 @@
       function check(node, reporter) {
 
         if (is$3(node, type)) {
-          reporter.report(node.id, 'Element has disallowed type <' + type + '>');
+          reporter.report(node.id, 'Element type <' + type + '> is discouraged');
         }
       }
 
@@ -119,7 +119,7 @@
 
   }
 
-  helper.disallowNodeType = disallowNodeType;
+  helper.checkDiscouragedNodeType = checkDiscouragedNodeType;
 
 
   /**

--- a/test/integration/bundling/test/app.webpack.expected.js
+++ b/test/integration/bundling/test/app.webpack.expected.js
@@ -148,7 +148,7 @@ const {
  *
  * @return { RuleFactory } ruleFactory
  */
-function disallowNodeType(type, ruleName) {
+function checkDiscouragedNodeType(type, ruleName) {
 
   /**
    * @type { RuleFactory }
@@ -158,7 +158,7 @@ function disallowNodeType(type, ruleName) {
     function check(node, reporter) {
 
       if (is(node, type)) {
-        reporter.report(node.id, 'Element has disallowed type <' + type + '>');
+        reporter.report(node.id, 'Element type <' + type + '> is discouraged');
       }
     }
 
@@ -170,7 +170,7 @@ function disallowNodeType(type, ruleName) {
 
 }
 
-module.exports.disallowNodeType = disallowNodeType;
+module.exports.checkDiscouragedNodeType = checkDiscouragedNodeType;
 
 
 /**

--- a/test/rules/no-complex-gateway.mjs
+++ b/test/rules/no-complex-gateway.mjs
@@ -24,7 +24,7 @@ RuleTester.verify('no-complex-gateway', rule, {
       moddleElement: readModdle(__dirname + '/no-complex-gateway/invalid.bpmn'),
       report: {
         id: 'Gateway',
-        message: 'Element has disallowed type <bpmn:ComplexGateway>'
+        message: 'Element type <bpmn:ComplexGateway> is discouraged'
       }
     }
   ]

--- a/test/rules/no-inclusive-gateway.mjs
+++ b/test/rules/no-inclusive-gateway.mjs
@@ -24,7 +24,7 @@ RuleTester.verify('no-inclusive-gateway', rule, {
       moddleElement: readModdle(__dirname + '/no-inclusive-gateway/invalid.bpmn'),
       report: {
         id: 'Gateway',
-        message: 'Element has disallowed type <bpmn:InclusiveGateway>'
+        message: 'Element type <bpmn:InclusiveGateway> is discouraged'
       }
     }
   ]


### PR DESCRIPTION
### Proposed Changes

Rather than calling out elements as "disallowed", frame element types as being "discouraged". This plays more nicely with different severity levels that folks can attach to lint results.

#### Example (informative)

```
INFO    GATEWAY_1    Element type <bpmn:InclusiveGateway> is discouraged
```

#### Example (error)

```
ERROR   GATEWAY_1    Element type <bpmn:InclusiveGateway> is discouraged
```


Try out using the following command:

```
npx @bpmn-io/sr bpmn-js-bpmnlint -l bpmn-io/bpmnlint#element-type-discouraged
```

![capture IYaYJJ_optimized](https://github.com/user-attachments/assets/80214c44-8751-46a2-a725-37f8ddd29d59)

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->

---

Related to [this conversation](https://camunda.slack.com/archives/C0693F1NFK5/p1740494040484239?thread_ts=1703070019.157809&cid=C0693F1NFK5).
