### PR TITLE
fix: do not require start and end event in ad-hoc subprocess

### DIFF
--- a/rules/end-event-required.js
+++ b/rules/end-event-required.js
@@ -28,7 +28,7 @@ module.exports = function() {
     if (!isAny(node, [
       'bpmn:Process',
       'bpmn:SubProcess'
-    ])) {
+    ]) || is(node, 'bpmn:AdHocSubProcess')) {
       return;
     }
 

--- a/rules/start-event-required.js
+++ b/rules/start-event-required.js
@@ -28,7 +28,7 @@ module.exports = function() {
     if (!isAny(node, [
       'bpmn:Process',
       'bpmn:SubProcess'
-    ])) {
+    ]) || is(node, 'bpmn:AdHocSubProcess')) {
       return;
     }
 

--- a/test/integration/bundling/test/app.rollup.expected.js
+++ b/test/integration/bundling/test/app.rollup.expected.js
@@ -1,431 +1,431 @@
 (function () {
-  'use strict';
-
-  function getDefaultExportFromCjs (x) {
-    return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
-  }
-
-  function getAugmentedNamespace(n) {
-    if (n.__esModule) return n;
-    var f = n.default;
-    if (typeof f == "function") {
-      var a = function a () {
-        if (this instanceof a) {
-          var args = [null];
-          args.push.apply(args, arguments);
-          var Ctor = Function.bind.apply(f, args);
-          return new Ctor();
-        }
-        return f.apply(this, arguments);
-      };
-      a.prototype = f.prototype;
-    } else a = {};
-    Object.defineProperty(a, '__esModule', {value: true});
-    Object.keys(n).forEach(function (k) {
-      var d = Object.getOwnPropertyDescriptor(n, k);
-      Object.defineProperty(a, k, d.get ? d : {
-        enumerable: true,
-        get: function () {
-          return n[k];
-        }
-      });
-    });
-    return a;
-  }
-
-  /**
-   * Checks whether node is of specific bpmn type.
-   *
-   * @param {ModdleElement} node
-   * @param {String} type
-   *
-   * @return {Boolean}
-   */
-  function is$4(node, type) {
-
-    if (type.indexOf(':') === -1) {
-      type = 'bpmn:' + type;
-    }
-
-    return (
-      (typeof node.$instanceOf === 'function')
-        ? node.$instanceOf(type)
-        : node.$type === type
-    );
-  }
-
-  /**
-   * Checks whether node has any of the specified types.
-   *
-   * @param {ModdleElement} node
-   * @param {Array<String>} types
-   *
-   * @return {Boolean}
-   */
-  function isAny$3(node, types) {
-    return types.some(function(type) {
-      return is$4(node, type);
-    });
-  }
-
-  var index_esm = /*#__PURE__*/Object.freeze({
-    __proto__: null,
-    is: is$4,
-    isAny: isAny$3
-  });
-
-  var require$$0 = /*@__PURE__*/getAugmentedNamespace(index_esm);
-
-  var helper = {};
-
-  const {
-    is: is$3
-  } = require$$0;
-
-  /**
-   * @typedef { import('../lib/types.js').ModdleElement } ModdleElement
-   *
-   * @typedef { import('../lib/types.js').RuleFactory } RuleFactory
-   * @typedef { import('../lib/types.js').RuleDefinition } RuleDefinition
-   */
-
-
-  /**
-   * Create a checker that disallows the given element type.
-   *
-   * @param { string } type
-   *
-   * @return { RuleFactory } ruleFactory
-   */
-  function checkDiscouragedNodeType(type, ruleName) {
-
-    /**
-     * @type { RuleFactory }
-     */
-    return function() {
-
-      function check(node, reporter) {
-
-        if (is$3(node, type)) {
-          reporter.report(node.id, 'Element type <' + type + '> is discouraged');
-        }
-      }
-
-      return annotateRule$3(ruleName, {
-        check
-      });
-
-    };
-
-  }
-
-  helper.checkDiscouragedNodeType = checkDiscouragedNodeType;
-
-
-  /**
-   * Find a parent for the given element
-   *
-   * @param { ModdleElement } node
-   * @param { string } type
-   *
-   * @return { ModdleElement } element
-   */
-  function findParent(node, type) {
-    if (!node) {
-      return null;
-    }
-
-    const parent = node.$parent;
-
-    if (!parent) {
-      return node;
-    }
-
-    if (is$3(parent, type)) {
-      return parent;
-    }
-
-    return findParent(parent, type);
-  }
-
-  helper.findParent = findParent;
-
-
-  const documentationBaseUrl = 'https://github.com/bpmn-io/bpmnlint/blob/main/docs/rules';
-
-  /**
-   * Annotate a rule with core information, such as the documentation url.
-   *
-   * @param {string} ruleName
-   * @param {RuleDefinition} options
-   *
-   * @return {RuleDefinition}
-   */
-  function annotateRule$3(ruleName, options) {
-
-    const {
-      meta: {
-        documentation = {},
-        ...restMeta
-      } = {},
-      ...restOptions
-    } = options;
-
-    const documentationUrl = `${documentationBaseUrl}/${ruleName}.md`;
-
-    return {
-      meta: {
-        documentation: {
-          url: documentationUrl,
-          ...documentation
-        },
-        ...restMeta
-      },
-      ...restOptions
-    };
-  }
-
-  helper.annotateRule = annotateRule$3;
-
-  const {
-    is: is$2,
-    isAny: isAny$2
-  } = require$$0;
-
-  const {
-    annotateRule: annotateRule$2
-  } = helper;
-
-
-  /**
-   * A rule that checks the presence of a label.
-   *
-   * @type { import('../lib/types.js').RuleFactory }
-   */
-  var labelRequired = function() {
-
-    function check(node, reporter) {
-
-      if (isAny$2(node, [
-        'bpmn:ParallelGateway',
-        'bpmn:EventBasedGateway'
-      ])) {
-        return;
-      }
-
-      // ignore joining gateways
-      if (is$2(node, 'bpmn:Gateway') && !isForking(node)) {
-        return;
-      }
-
-      // ignore sub-processes
-      if (is$2(node, 'bpmn:SubProcess')) {
-
-        // TODO(nikku): better ignore expanded sub-processes only
-        return;
-      }
-
-      // ignore sequence flow without condition
-      if (is$2(node, 'bpmn:SequenceFlow') && !hasCondition(node)) {
-        return;
-      }
-
-      // ignore data objects and artifacts for now
-      if (isAny$2(node, [
-        'bpmn:FlowNode',
-        'bpmn:SequenceFlow',
-        'bpmn:Participant',
-        'bpmn:Lane'
-      ])) {
-
-        const name = (node.name || '').trim();
-
-        if (name.length === 0) {
-          reporter.report(node.id, 'Element is missing label/name', [ 'name' ]);
-        }
-      }
-    }
-
-    return annotateRule$2('label-required', {
-      check
-    });
-  };
-
-
-  // helpers ////////////////////////
-
-  function isForking(node) {
-    const outgoing = node.outgoing || [];
-
-    return outgoing.length > 1;
-  }
-
-  function hasCondition(node) {
-    return node.conditionExpression;
-  }
-
-  var rule_0 = /*@__PURE__*/getDefaultExportFromCjs(labelRequired);
-
-  const {
-    is: is$1,
-    isAny: isAny$1
-  } = require$$0;
-
-  const {
-    annotateRule: annotateRule$1
-  } = helper;
-
-
-  /**
-   * A rule that checks for the presence of a start event per scope.
-   *
-   * @type { import('../lib/types.js').RuleFactory }
-   */
-  var startEventRequired = function() {
-
-    function hasStartEvent(node) {
-      const flowElements = node.flowElements || [];
-
-      return (
-        flowElements.some(node => is$1(node, 'bpmn:StartEvent'))
-      );
-    }
-
-    function check(node, reporter) {
-
-      if (!isAny$1(node, [
-        'bpmn:Process',
-        'bpmn:SubProcess'
-      ])) {
-        return;
-      }
+	'use strict';
+
+	function getDefaultExportFromCjs (x) {
+		return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+	}
+
+	function getAugmentedNamespace(n) {
+	  if (n.__esModule) return n;
+	  var f = n.default;
+		if (typeof f == "function") {
+			var a = function a () {
+				if (this instanceof a) {
+					var args = [null];
+					args.push.apply(args, arguments);
+					var Ctor = Function.bind.apply(f, args);
+					return new Ctor();
+				}
+				return f.apply(this, arguments);
+			};
+			a.prototype = f.prototype;
+	  } else a = {};
+	  Object.defineProperty(a, '__esModule', {value: true});
+		Object.keys(n).forEach(function (k) {
+			var d = Object.getOwnPropertyDescriptor(n, k);
+			Object.defineProperty(a, k, d.get ? d : {
+				enumerable: true,
+				get: function () {
+					return n[k];
+				}
+			});
+		});
+		return a;
+	}
+
+	/**
+	 * Checks whether node is of specific bpmn type.
+	 *
+	 * @param {ModdleElement} node
+	 * @param {String} type
+	 *
+	 * @return {Boolean}
+	 */
+	function is$4(node, type) {
+
+	  if (type.indexOf(':') === -1) {
+	    type = 'bpmn:' + type;
+	  }
+
+	  return (
+	    (typeof node.$instanceOf === 'function')
+	      ? node.$instanceOf(type)
+	      : node.$type === type
+	  );
+	}
+
+	/**
+	 * Checks whether node has any of the specified types.
+	 *
+	 * @param {ModdleElement} node
+	 * @param {Array<String>} types
+	 *
+	 * @return {Boolean}
+	 */
+	function isAny$3(node, types) {
+	  return types.some(function(type) {
+	    return is$4(node, type);
+	  });
+	}
+
+	var index_esm = /*#__PURE__*/Object.freeze({
+		__proto__: null,
+		is: is$4,
+		isAny: isAny$3
+	});
+
+	var require$$0 = /*@__PURE__*/getAugmentedNamespace(index_esm);
+
+	var helper = {};
+
+	const {
+	  is: is$3
+	} = require$$0;
+
+	/**
+	 * @typedef { import('../lib/types.js').ModdleElement } ModdleElement
+	 *
+	 * @typedef { import('../lib/types.js').RuleFactory } RuleFactory
+	 * @typedef { import('../lib/types.js').RuleDefinition } RuleDefinition
+	 */
+
+
+	/**
+	 * Create a checker that disallows the given element type.
+	 *
+	 * @param { string } type
+	 *
+	 * @return { RuleFactory } ruleFactory
+	 */
+	function checkDiscouragedNodeType(type, ruleName) {
+
+	  /**
+	   * @type { RuleFactory }
+	   */
+	  return function() {
+
+	    function check(node, reporter) {
+
+	      if (is$3(node, type)) {
+	        reporter.report(node.id, 'Element type <' + type + '> is discouraged');
+	      }
+	    }
+
+	    return annotateRule$3(ruleName, {
+	      check
+	    });
+
+	  };
+
+	}
+
+	helper.checkDiscouragedNodeType = checkDiscouragedNodeType;
+
+
+	/**
+	 * Find a parent for the given element
+	 *
+	 * @param { ModdleElement } node
+	 * @param { string } type
+	 *
+	 * @return { ModdleElement } element
+	 */
+	function findParent(node, type) {
+	  if (!node) {
+	    return null;
+	  }
+
+	  const parent = node.$parent;
+
+	  if (!parent) {
+	    return node;
+	  }
+
+	  if (is$3(parent, type)) {
+	    return parent;
+	  }
+
+	  return findParent(parent, type);
+	}
+
+	helper.findParent = findParent;
+
+
+	const documentationBaseUrl = 'https://github.com/bpmn-io/bpmnlint/blob/main/docs/rules';
+
+	/**
+	 * Annotate a rule with core information, such as the documentation url.
+	 *
+	 * @param {string} ruleName
+	 * @param {RuleDefinition} options
+	 *
+	 * @return {RuleDefinition}
+	 */
+	function annotateRule$3(ruleName, options) {
+
+	  const {
+	    meta: {
+	      documentation = {},
+	      ...restMeta
+	    } = {},
+	    ...restOptions
+	  } = options;
+
+	  const documentationUrl = `${documentationBaseUrl}/${ruleName}.md`;
+
+	  return {
+	    meta: {
+	      documentation: {
+	        url: documentationUrl,
+	        ...documentation
+	      },
+	      ...restMeta
+	    },
+	    ...restOptions
+	  };
+	}
+
+	helper.annotateRule = annotateRule$3;
+
+	const {
+	  is: is$2,
+	  isAny: isAny$2
+	} = require$$0;
+
+	const {
+	  annotateRule: annotateRule$2
+	} = helper;
+
+
+	/**
+	 * A rule that checks the presence of a label.
+	 *
+	 * @type { import('../lib/types.js').RuleFactory }
+	 */
+	var labelRequired = function() {
+
+	  function check(node, reporter) {
+
+	    if (isAny$2(node, [
+	      'bpmn:ParallelGateway',
+	      'bpmn:EventBasedGateway'
+	    ])) {
+	      return;
+	    }
+
+	    // ignore joining gateways
+	    if (is$2(node, 'bpmn:Gateway') && !isForking(node)) {
+	      return;
+	    }
+
+	    // ignore sub-processes
+	    if (is$2(node, 'bpmn:SubProcess')) {
+
+	      // TODO(nikku): better ignore expanded sub-processes only
+	      return;
+	    }
+
+	    // ignore sequence flow without condition
+	    if (is$2(node, 'bpmn:SequenceFlow') && !hasCondition(node)) {
+	      return;
+	    }
+
+	    // ignore data objects and artifacts for now
+	    if (isAny$2(node, [
+	      'bpmn:FlowNode',
+	      'bpmn:SequenceFlow',
+	      'bpmn:Participant',
+	      'bpmn:Lane'
+	    ])) {
+
+	      const name = (node.name || '').trim();
+
+	      if (name.length === 0) {
+	        reporter.report(node.id, 'Element is missing label/name', [ 'name' ]);
+	      }
+	    }
+	  }
+
+	  return annotateRule$2('label-required', {
+	    check
+	  });
+	};
+
+
+	// helpers ////////////////////////
+
+	function isForking(node) {
+	  const outgoing = node.outgoing || [];
+
+	  return outgoing.length > 1;
+	}
+
+	function hasCondition(node) {
+	  return node.conditionExpression;
+	}
+
+	var rule_0 = /*@__PURE__*/getDefaultExportFromCjs(labelRequired);
+
+	const {
+	  is: is$1,
+	  isAny: isAny$1
+	} = require$$0;
+
+	const {
+	  annotateRule: annotateRule$1
+	} = helper;
+
+
+	/**
+	 * A rule that checks for the presence of a start event per scope.
+	 *
+	 * @type { import('../lib/types.js').RuleFactory }
+	 */
+	var startEventRequired = function() {
+
+	  function hasStartEvent(node) {
+	    const flowElements = node.flowElements || [];
+
+	    return (
+	      flowElements.some(node => is$1(node, 'bpmn:StartEvent'))
+	    );
+	  }
+
+	  function check(node, reporter) {
+
+	    if (!isAny$1(node, [
+	      'bpmn:Process',
+	      'bpmn:SubProcess'
+	    ]) || is$1(node, 'bpmn:AdHocSubProcess')) {
+	      return;
+	    }
 
-      if (!hasStartEvent(node)) {
-        const type = is$1(node, 'bpmn:SubProcess') ? 'Sub process' : 'Process';
-
-        reporter.report(node.id, type + ' is missing start event');
-      }
-    }
-
-    return annotateRule$1('start-event-required', {
-      check
-    });
-  };
-
-  var rule_1 = /*@__PURE__*/getDefaultExportFromCjs(startEventRequired);
-
-  const {
-    is,
-    isAny
-  } = require$$0;
-
-  const {
-    annotateRule
-  } = helper;
+	    if (!hasStartEvent(node)) {
+	      const type = is$1(node, 'bpmn:SubProcess') ? 'Sub process' : 'Process';
+
+	      reporter.report(node.id, type + ' is missing start event');
+	    }
+	  }
+
+	  return annotateRule$1('start-event-required', {
+	    check
+	  });
+	};
+
+	var rule_1 = /*@__PURE__*/getDefaultExportFromCjs(startEventRequired);
+
+	const {
+	  is,
+	  isAny
+	} = require$$0;
+
+	const {
+	  annotateRule
+	} = helper;
 
 
-  /**
-   * A rule that checks the presence of an end event per scope.
-   *
-   * @type { import('../lib/types.js').RuleFactory }
-   */
-  var endEventRequired = function() {
+	/**
+	 * A rule that checks the presence of an end event per scope.
+	 *
+	 * @type { import('../lib/types.js').RuleFactory }
+	 */
+	var endEventRequired = function() {
 
-    function hasEndEvent(node) {
-      const flowElements = node.flowElements || [];
+	  function hasEndEvent(node) {
+	    const flowElements = node.flowElements || [];
 
-      return (
-        flowElements.some(node => is(node, 'bpmn:EndEvent'))
-      );
-    }
+	    return (
+	      flowElements.some(node => is(node, 'bpmn:EndEvent'))
+	    );
+	  }
 
-    function check(node, reporter) {
+	  function check(node, reporter) {
 
-      if (!isAny(node, [
-        'bpmn:Process',
-        'bpmn:SubProcess'
-      ])) {
-        return;
-      }
+	    if (!isAny(node, [
+	      'bpmn:Process',
+	      'bpmn:SubProcess'
+	    ]) || is(node, 'bpmn:AdHocSubProcess')) {
+	      return;
+	    }
 
-      if (!hasEndEvent(node)) {
-        const type = is(node, 'bpmn:SubProcess') ? 'Sub process' : 'Process';
+	    if (!hasEndEvent(node)) {
+	      const type = is(node, 'bpmn:SubProcess') ? 'Sub process' : 'Process';
 
-        reporter.report(node.id, type + ' is missing end event');
-      }
-    }
+	      reporter.report(node.id, type + ' is missing end event');
+	    }
+	  }
 
-    return annotateRule('end-event-required', {
-      check
-    });
-  };
+	  return annotateRule('end-event-required', {
+	    check
+	  });
+	};
 
-  var rule_2 = /*@__PURE__*/getDefaultExportFromCjs(endEventRequired);
+	var rule_2 = /*@__PURE__*/getDefaultExportFromCjs(endEventRequired);
 
-  var foo = function foo() {
-    return {
-      check() {}
-    };
-  };
+	var foo = function foo() {
+	  return {
+	    check() {}
+	  };
+	};
 
-  var rule_4 = /*@__PURE__*/getDefaultExportFromCjs(foo);
+	var rule_4 = /*@__PURE__*/getDefaultExportFromCjs(foo);
 
-  const cache = {};
+	const cache = {};
 
-  /**
-   * A resolver that caches rules and configuration as part of the bundle,
-   * making them accessible in the browser.
-   *
-   * @param {Object} cache
-   */
-  function Resolver() {}
+	/**
+	 * A resolver that caches rules and configuration as part of the bundle,
+	 * making them accessible in the browser.
+	 *
+	 * @param {Object} cache
+	 */
+	function Resolver() {}
 
-  Resolver.prototype.resolveRule = function(pkg, ruleName) {
+	Resolver.prototype.resolveRule = function(pkg, ruleName) {
 
-    const rule = cache[pkg + '/' + ruleName];
+	  const rule = cache[pkg + '/' + ruleName];
 
-    if (!rule) {
-      throw new Error('cannot resolve rule <' + pkg + '/' + ruleName + '>: not bundled');
-    }
+	  if (!rule) {
+	    throw new Error('cannot resolve rule <' + pkg + '/' + ruleName + '>: not bundled');
+	  }
 
-    return rule;
-  };
+	  return rule;
+	};
 
-  Resolver.prototype.resolveConfig = function(pkg, configName) {
-    throw new Error(
-      'cannot resolve config <' + configName + '> in <' + pkg +'>: not bundled'
-    );
-  };
+	Resolver.prototype.resolveConfig = function(pkg, configName) {
+	  throw new Error(
+	    'cannot resolve config <' + configName + '> in <' + pkg +'>: not bundled'
+	  );
+	};
 
-  const resolver = new Resolver();
+	const resolver = new Resolver();
 
-  const rules = {
-    "label-required": 1,
-    "start-event-required": "info",
-    "end-event-required": 2,
-    "exported/foo": "error",
-    "exported/foo-absolute": "error"
-  };
+	const rules = {
+	  "label-required": 1,
+	  "start-event-required": "info",
+	  "end-event-required": 2,
+	  "exported/foo": "error",
+	  "exported/foo-absolute": "error"
+	};
 
-  const config = {
-    rules: rules
-  };
+	const config = {
+	  rules: rules
+	};
 
-  const bundle = {
-    resolver: resolver,
-    config: config
-  };
+	const bundle = {
+	  resolver: resolver,
+	  config: config
+	};
 
-  cache['bpmnlint/label-required'] = rule_0;
+	cache['bpmnlint/label-required'] = rule_0;
 
-  cache['bpmnlint/start-event-required'] = rule_1;
+	cache['bpmnlint/start-event-required'] = rule_1;
 
-  cache['bpmnlint/end-event-required'] = rule_2;
+	cache['bpmnlint/end-event-required'] = rule_2;
 
-  cache['bpmnlint-plugin-exported/foo'] = rule_4;
+	cache['bpmnlint-plugin-exported/foo'] = rule_4;
 
-  cache['bpmnlint-plugin-exported/foo-absolute'] = rule_4;
+	cache['bpmnlint-plugin-exported/foo-absolute'] = rule_4;
 
-  console.log(bundle);
+	console.log(bundle);
 
 })();

--- a/test/integration/bundling/test/app.webpack.expected.js
+++ b/test/integration/bundling/test/app.webpack.expected.js
@@ -1,5 +1,5 @@
 /******/ (() => { // webpackBootstrap
-/******/   var __webpack_modules__ = ({
+/******/ 	var __webpack_modules__ = ({
 
 /***/ "./node_modules/bpmnlint-plugin-exported/src/foo.js":
 /*!**********************************************************!*\
@@ -104,7 +104,7 @@ module.exports = function() {
     if (!isAny(node, [
       'bpmn:Process',
       'bpmn:SubProcess'
-    ])) {
+    ]) || is(node, 'bpmn:AdHocSubProcess')) {
       return;
     }
 
@@ -361,7 +361,7 @@ module.exports = function() {
     if (!isAny(node, [
       'bpmn:Process',
       'bpmn:SubProcess'
-    ])) {
+    ]) || is(node, 'bpmn:AdHocSubProcess')) {
       return;
     }
 
@@ -474,73 +474,73 @@ cache['bpmnlint-plugin-exported/foo-absolute'] = (bpmnlint_plugin_exported_src_f
 
 /***/ })
 
-/******/   });
+/******/ 	});
 /************************************************************************/
-/******/   // The module cache
-/******/   var __webpack_module_cache__ = {};
-/******/   
-/******/   // The require function
-/******/   function __webpack_require__(moduleId) {
-/******/     // Check if module is in cache
-/******/     var cachedModule = __webpack_module_cache__[moduleId];
-/******/     if (cachedModule !== undefined) {
-/******/       return cachedModule.exports;
-/******/     }
-/******/     // Create a new module (and put it into the cache)
-/******/     var module = __webpack_module_cache__[moduleId] = {
-/******/       // no module.id needed
-/******/       // no module.loaded needed
-/******/       exports: {}
-/******/     };
-/******/   
-/******/     // Execute the module function
-/******/     __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
-/******/   
-/******/     // Return the exports of the module
-/******/     return module.exports;
-/******/   }
-/******/   
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
 /************************************************************************/
-/******/   /* webpack/runtime/compat get default export */
-/******/   (() => {
-/******/     // getDefaultExport function for compatibility with non-harmony modules
-/******/     __webpack_require__.n = (module) => {
-/******/       var getter = module && module.__esModule ?
-/******/         () => (module['default']) :
-/******/         () => (module);
-/******/       __webpack_require__.d(getter, { a: getter });
-/******/       return getter;
-/******/     };
-/******/   })();
-/******/   
-/******/   /* webpack/runtime/define property getters */
-/******/   (() => {
-/******/     // define getter functions for harmony exports
-/******/     __webpack_require__.d = (exports, definition) => {
-/******/       for(var key in definition) {
-/******/         if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-/******/           Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-/******/         }
-/******/       }
-/******/     };
-/******/   })();
-/******/   
-/******/   /* webpack/runtime/hasOwnProperty shorthand */
-/******/   (() => {
-/******/     __webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
-/******/   })();
-/******/   
-/******/   /* webpack/runtime/make namespace object */
-/******/   (() => {
-/******/     // define __esModule on exports
-/******/     __webpack_require__.r = (exports) => {
-/******/       if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
-/******/         Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-/******/       }
-/******/       Object.defineProperty(exports, '__esModule', { value: true });
-/******/     };
-/******/   })();
-/******/   
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	(() => {
+/******/ 		// getDefaultExport function for compatibility with non-harmony modules
+/******/ 		__webpack_require__.n = (module) => {
+/******/ 			var getter = module && module.__esModule ?
+/******/ 				() => (module['default']) :
+/******/ 				() => (module);
+/******/ 			__webpack_require__.d(getter, { a: getter });
+/******/ 			return getter;
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	(() => {
+/******/ 		// define getter functions for harmony exports
+/******/ 		__webpack_require__.d = (exports, definition) => {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
+/******/ 			}
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	(() => {
+/******/ 		__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/make namespace object */
+/******/ 	(() => {
+/******/ 		// define __esModule on exports
+/******/ 		__webpack_require__.r = (exports) => {
+/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 			}
+/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 		};
+/******/ 	})();
+/******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry needs to be wrapped in an IIFE because it needs to be in strict mode.

--- a/test/rules/end-event-required.mjs
+++ b/test/rules/end-event-required.mjs
@@ -20,6 +20,9 @@ RuleTester.verify('end-event-required', rule, {
     },
     {
       moddleElement: readModdle(__dirname + '/end-event-required/valid-sub-process.bpmn')
+    },
+    {
+      moddleElement: readModdle(__dirname + '/end-event-required/valid-sub-process-sub-types.bpmn')
     }
   ],
   invalid: [
@@ -36,6 +39,19 @@ RuleTester.verify('end-event-required', rule, {
         id: 'SubProcess',
         message: 'Sub process is missing end event'
       }
+    },
+    {
+      moddleElement: readModdle(__dirname + '/end-event-required/invalid-sub-process-sub-types.bpmn'),
+      report: [
+        {
+          id: 'TRANSACTION',
+          message: 'Sub process is missing end event'
+        },
+        {
+          id: 'EVENT_SUBPROCESS',
+          message: 'Sub process is missing end event'
+        }
+      ]
     }
   ]
 });

--- a/test/rules/end-event-required/invalid-sub-process-sub-types.bpmn
+++ b/test/rules/end-event-required/invalid-sub-process-sub-types.bpmn
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_0z49faa" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0">
+  <bpmn:process id="Process" isExecutable="true">
+    <bpmn:endEvent id="EndEvent" />
+    <bpmn:transaction id="TRANSACTION" />
+    <bpmn:subProcess id="EVENT_SUBPROCESS" triggeredByEvent="true" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process">
+      <bpmndi:BPMNShape id="EndEvent_di" bpmnElement="EndEvent">
+        <dc:Bounds x="123" y="121" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1s1e2o3_di" bpmnElement="TRANSACTION" isExpanded="true">
+        <dc:Bounds x="191" y="280" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09auhi3_di" bpmnElement="EVENT_SUBPROCESS" isExpanded="true">
+        <dc:Bounds x="570" y="280" width="350" height="200" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/rules/end-event-required/valid-sub-process-sub-types.bpmn
+++ b/test/rules/end-event-required/valid-sub-process-sub-types.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_0z49faa" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0">
+  <bpmn:process id="Process" isExecutable="true">
+    <bpmn:endEvent id="EndEvent" />
+    <bpmn:transaction id="TRANSACTION">
+      <bpmn:endEvent id="Event_0hqijfe" />
+    </bpmn:transaction>
+    <bpmn:subProcess id="EVENT_SUBPROCESS" triggeredByEvent="true">
+      <bpmn:endEvent id="Event_1yleh1s">
+        <bpmn:messageEventDefinition id="MessageEventDefinition_1dj7o2m" />
+      </bpmn:endEvent>
+    </bpmn:subProcess>
+    <bpmn:adHocSubProcess id="SubProcess" name="not required" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process">
+      <bpmndi:BPMNShape id="EndEvent_di" bpmnElement="EndEvent">
+        <dc:Bounds x="123" y="121" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1s1e2o3_di" bpmnElement="TRANSACTION" isExpanded="true">
+        <dc:Bounds x="191" y="280" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0gx8szb" bpmnElement="Event_0hqijfe">
+        <dc:Bounds x="234" y="362" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09auhi3_di" bpmnElement="EVENT_SUBPROCESS" isExpanded="true">
+        <dc:Bounds x="570" y="280" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_10jcpqb_di" bpmnElement="Event_1yleh1s">
+        <dc:Bounds x="613" y="362" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1phfgs7_di" bpmnElement="SubProcess" isExpanded="true">
+        <dc:Bounds x="191" y="39" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/rules/start-event-required.mjs
+++ b/test/rules/start-event-required.mjs
@@ -20,6 +20,9 @@ RuleTester.verify('start-event-required', rule, {
     },
     {
       moddleElement: readModdle(__dirname + '/start-event-required/valid-sub-process.bpmn')
+    },
+    {
+      moddleElement: readModdle(__dirname + '/start-event-required/valid-sub-process-sub-types.bpmn')
     }
   ],
   invalid: [
@@ -36,6 +39,19 @@ RuleTester.verify('start-event-required', rule, {
         id: 'SubProcess',
         message: 'Sub process is missing start event'
       }
+    },
+    {
+      moddleElement: readModdle(__dirname + '/start-event-required/invalid-sub-process-sub-types.bpmn'),
+      report: [
+        {
+          id: 'TRANSACTION',
+          message: 'Sub process is missing start event'
+        },
+        {
+          id: 'EVENT_SUBPROCESS',
+          message: 'Sub process is missing start event'
+        }
+      ]
     }
   ]
 });

--- a/test/rules/start-event-required/invalid-sub-process-sub-types.bpmn
+++ b/test/rules/start-event-required/invalid-sub-process-sub-types.bpmn
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_0z49faa" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0">
+  <bpmn:process id="Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent" />
+    <bpmn:transaction id="TRANSACTION" />
+    <bpmn:subProcess id="EVENT_SUBPROCESS" triggeredByEvent="true" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process">
+      <bpmndi:BPMNShape id="StartEvent_di" bpmnElement="StartEvent">
+        <dc:Bounds x="123" y="121" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1s1e2o3_di" bpmnElement="TRANSACTION" isExpanded="true">
+        <dc:Bounds x="191" y="280" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09auhi3_di" bpmnElement="EVENT_SUBPROCESS" isExpanded="true">
+        <dc:Bounds x="570" y="280" width="350" height="200" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/rules/start-event-required/valid-sub-process-sub-types.bpmn
+++ b/test/rules/start-event-required/valid-sub-process-sub-types.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_0z49faa" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0">
+  <bpmn:process id="Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent" />
+    <bpmn:transaction id="TRANSACTION">
+      <bpmn:startEvent id="Event_0hqijfe" />
+    </bpmn:transaction>
+    <bpmn:subProcess id="EVENT_SUBPROCESS" triggeredByEvent="true">
+      <bpmn:startEvent id="Event_1yleh1s">
+        <bpmn:messageEventDefinition id="MessageEventDefinition_1dj7o2m" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:adHocSubProcess id="SubProcess" name="not required" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process">
+      <bpmndi:BPMNShape id="StartEvent_di" bpmnElement="StartEvent">
+        <dc:Bounds x="123" y="121" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1s1e2o3_di" bpmnElement="TRANSACTION" isExpanded="true">
+        <dc:Bounds x="191" y="280" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0gx8szb" bpmnElement="Event_0hqijfe">
+        <dc:Bounds x="234" y="362" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09auhi3_di" bpmnElement="EVENT_SUBPROCESS" isExpanded="true">
+        <dc:Bounds x="570" y="280" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_10jcpqb_di" bpmnElement="Event_1yleh1s">
+        <dc:Bounds x="613" y="362" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1phfgs7_di" bpmnElement="SubProcess" isExpanded="true">
+        <dc:Bounds x="191" y="39" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
### Proposed Changes

AdHoc SubProcess must not have start or end event, so we should not require them to be present.

Closes #175
<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
