### PR TITLE
fix: only check catch events in adhoc

### DIFF
--- a/docs/rules/ad-hoc-sub-process.md
+++ b/docs/rules/ad-hoc-sub-process.md
@@ -3,7 +3,7 @@
 Ensure that an Ad-Hoc Sub-Process is valid according to the BPMN specification:
 
 - Must not contain start or end events.
-- Every intermediate event must have an outgoing sequence flow.
+- Every intermediate catch event must have an outgoing sequence flow.
 
 
 Example of __incorrect__ usage for this rule:

--- a/rules/ad-hoc-sub-process.js
+++ b/rules/ad-hoc-sub-process.js
@@ -1,6 +1,5 @@
 const {
-  is,
-  isAny
+  is
 } = require('bpmnlint-utils');
 
 const {
@@ -36,9 +35,9 @@ module.exports = function() {
         reporter.report(flowElement.id, 'An <End Event> is not allowed in <Ad Hoc Sub Process>');
       }
 
-      if (isAny(flowElement, [ 'bpmn:IntermediateCatchEvent', 'bpmn:IntermediateThrowEvent' ])) {
+      if (is(flowElement, 'bpmn:IntermediateCatchEvent')) {
         if (!flowElement.outgoing || flowElement.outgoing.length === 0) {
-          reporter.report(flowElement.id, 'An intermediate event inside <Ad Hoc Sub Process> must have an outgoing sequence flow');
+          reporter.report(flowElement.id, 'An intermediate catch event inside <Ad Hoc Sub Process> must have an outgoing sequence flow');
         }
       }
 

--- a/test/rules/ad-hoc-sub-process.mjs
+++ b/test/rules/ad-hoc-sub-process.mjs
@@ -37,12 +37,8 @@ RuleTester.verify('ad-hoc-sub-process', rule, {
       moddleElement: readModdle(__dirname + '/ad-hoc-sub-process/invalid-intermediate.bpmn'),
       report: [
         {
-          id: 'ThrowEvent',
-          message: 'An intermediate event inside <Ad Hoc Sub Process> must have an outgoing sequence flow'
-        },
-        {
           id: 'CatchEvent',
-          message: 'An intermediate event inside <Ad Hoc Sub Process> must have an outgoing sequence flow'
+          message: 'An intermediate catch event inside <Ad Hoc Sub Process> must have an outgoing sequence flow'
         }
       ]
     }


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/4985

### Proposed Changes

Only check that intermediate *catch* events have outgoing sequence flow. intermediate *throw* events don't necessarily need outgoing sequence flow.

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
