### PR TITLE
Allow to set moddle extensions in the config

### DIFF
--- a/lib/resolver/helper.js
+++ b/lib/resolver/helper.js
@@ -1,0 +1,12 @@
+const Module = require('node:module');
+const path = require('node:path');
+
+/**
+ * Create require function for a given path.
+ *
+ * @param {string} cwd
+ * @returns {NodeRequire}
+ */
+module.exports.createScopedRequire = function(cwd) {
+  return Module.createRequire(path.join(cwd, '__placeholder__.js'));
+};

--- a/lib/resolver/node-resolver.js
+++ b/lib/resolver/node-resolver.js
@@ -1,4 +1,3 @@
-const Module = require('node:module');
 const path = require('node:path');
 const { cwd } = require('node:process');
 
@@ -9,6 +8,7 @@ const { isString } = require('min-dash');
  * @typedef { import('../types.js').Config } Config
  */
 
+const { createScopedRequire } = require('./helper');
 
 /**
  * A resolver that locates rules and configurations
@@ -134,12 +134,3 @@ NodeResolver.prototype.normalizePkg = function(pkg) {
 
   return pkg;
 };
-
-// helpers ////////////////////
-
-/**
- * @param {string} cwd
- */
-function createScopedRequire(cwd) {
-  return Module.createRequire(path.join(cwd, '__placeholder__.js'));
-}

--- a/test/integration/bpmnlint-plugin-test-camunda/index.js
+++ b/test/integration/bpmnlint-plugin-test-camunda/index.js
@@ -1,0 +1,9 @@
+module.exports = {
+  configs: {
+    recommended: {
+      rules: {
+        'no-service-task-like': 'error'
+      }
+    }
+  }
+};

--- a/test/integration/bpmnlint-plugin-test-camunda/package.json
+++ b/test/integration/bpmnlint-plugin-test-camunda/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "bpmnlint-plugin-test-camunda",
+  "version": "0.0.0",
+  "description": "A test bpmnlint plug-in",
+  "main": "index.js"
+}

--- a/test/integration/bpmnlint-plugin-test-camunda/rules/no-service-task-like.js
+++ b/test/integration/bpmnlint-plugin-test-camunda/rules/no-service-task-like.js
@@ -1,0 +1,15 @@
+/**
+ * Rule that reports `camunda:ServiceTaskLike`.
+ */
+module.exports = function() {
+
+  function check(node, reporter) {
+    if (node.$instanceOf('camunda:ServiceTaskLike')) {
+      reporter.report(node.id, 'Element is a camunda:ServiceTaskLike <' + node.name + '>');
+    }
+  }
+
+  return {
+    check: check
+  };
+};

--- a/test/integration/cli-spec.mjs
+++ b/test/integration/cli-spec.mjs
@@ -426,6 +426,23 @@ describe('cli', function() {
         stdout: EMPTY
       }
     });
+
+
+    verify({
+      cmd: [ 'bpmnlint', '-c', 'bpmnlintrc-relative-extension.json', 'diagram.bpmn' ],
+      cwd: __dirname + '/cli/moddle-extension',
+      expect: {
+        code: 1,
+        stderr: EMPTY,
+        stdout: `
+
+        ${diagramPath('moddle-extension/diagram.bpmn')}
+          ServiceTask  error  Element is a camunda:ServiceTaskLike <Service Task>  test-camunda/no-service-task-like
+
+        ✖ 1 problem (1 error, 0 warnings)
+      `
+      }
+    });
   });
 
 });

--- a/test/integration/cli/moddle-extension/.bpmnlintrc
+++ b/test/integration/cli/moddle-extension/.bpmnlintrc
@@ -1,0 +1,6 @@
+{
+  "extends": "plugin:test-camunda/recommended",
+  "moddleExtensions": {
+    "camunda": "camunda-bpmn-moddle/resources/camunda.json"
+  }
+}

--- a/test/integration/cli/moddle-extension/bpmnlintrc-missing-extension.json
+++ b/test/integration/cli/moddle-extension/bpmnlintrc-missing-extension.json
@@ -1,0 +1,6 @@
+{
+  "extends": "plugin:test-camunda/recommended",
+  "moddleExtensions": {
+    "missing-extension": "./non-existing.json"
+  }
+}

--- a/test/integration/cli/moddle-extension/bpmnlintrc-relative-extension.json
+++ b/test/integration/cli/moddle-extension/bpmnlintrc-relative-extension.json
@@ -1,0 +1,6 @@
+{
+  "extends": "plugin:test-camunda/recommended",
+  "moddleExtensions": {
+    "camunda": "./node_modules/camunda-bpmn-moddle/resources/camunda.json"
+  }
+}

--- a/test/integration/cli/moddle-extension/diagram.bpmn
+++ b/test/integration/cli/moddle-extension/diagram.bpmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sid-38422fae-e03e-43a3-bef4-bd33b32041b2" targetNamespace="http://bpmn.io/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1">
+  <process id="Process" isExecutable="false">
+    <startEvent id="StartEvent" name="GOOD">
+      <outgoing>Flow_02gf09w</outgoing>
+    </startEvent>
+    <sequenceFlow id="Flow_02gf09w" sourceRef="StartEvent" targetRef="ServiceTask" />
+    <serviceTask id="ServiceTask" name="Service Task">
+      <incoming>Flow_02gf09w</incoming>
+    </serviceTask>
+  </process>
+  <bpmndi:BPMNDiagram id="BpmnDiagram_1">
+    <bpmndi:BPMNPlane id="BpmnPlane_1" bpmnElement="Process">
+      <bpmndi:BPMNEdge id="Flow_02gf09w_di" bpmnElement="Flow_02gf09w">
+        <di:waypoint x="194" y="118" />
+        <di:waypoint x="250" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="StartEvent_di" bpmnElement="StartEvent">
+        <omgdc:Bounds x="158" y="100" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="160" y="143" width="34" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1w1zjib_di" bpmnElement="ServiceTask">
+        <omgdc:Bounds x="250" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/test/integration/cli/moddle-extension/package-lock.json
+++ b/test/integration/cli/moddle-extension/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "moddle-extension-test",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "camunda-bpmn-moddle": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-moddle/-/camunda-bpmn-moddle-6.1.2.tgz",
+      "integrity": "sha512-DfhOTeq8oN01cB5sLE6Rq34/9xGD15/Y14pEM+YBIjgvV6Rclh+BgIa/2aRMm8An4Kc/itm2tECYiDr8p/FyTQ==",
+      "requires": {
+        "min-dash": "^3.8.1"
+      }
+    },
+    "min-dash": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+      "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
+    }
+  }
+}

--- a/test/integration/cli/moddle-extension/package.json
+++ b/test/integration/cli/moddle-extension/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "moddle-extension-test",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "bpmnlint-plugin-test-camunda": "file:../../bpmnlint-plugin-test-camunda",
+    "camunda-bpmn-moddle": "^6.1.2"
+  },
+  "localDependencies": {
+    "bpmnlint-plugin-test-camunda": "../../bpmnlint-plugin-test-camunda"
+  }
+}


### PR DESCRIPTION
### Proposed Changes

This allows users to declare `moddleExtensions` in the ROOT bpmnlint configuration file.

Nested configurations are not supported for the moment, but may be supported at some stage.

Implements what is sketched via https://github.com/bpmn-io/bpmnlint/issues/62

Implementation and integration tests ensure that extension is loaded locally to the actual bpmnlint configuration (and the project to be tested). 


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->


Closes https://github.com/bpmn-io/bpmnlint/issues/62
Closes https://github.com/bpmn-io/bpmnlint/issues/8
