### PR TITLE
fix: change no-inclusive-gateway to warn

### DIFF
--- a/config/recommended.js
+++ b/config/recommended.js
@@ -17,7 +17,7 @@ module.exports = {
     'no-implicit-split': 'error',
     'no-implicit-end': 'error',
     'no-implicit-start': 'error',
-    'no-inclusive-gateway': 'error',
+    'no-inclusive-gateway': 'warn',
     'no-overlapping-elements': 'warn',
     'single-blank-start-event': 'error',
     'single-event-definition': 'error',

--- a/test/integration/compilation/test/bpmnlintrc.expected.js
+++ b/test/integration/compilation/test/bpmnlintrc.expected.js
@@ -46,7 +46,7 @@ const rules = {
   "no-implicit-split": "error",
   "no-implicit-end": "error",
   "no-implicit-start": "error",
-  "no-inclusive-gateway": "error",
+  "no-inclusive-gateway": "warn",
   "no-overlapping-elements": "warn",
   "single-blank-start-event": "error",
   "single-event-definition": "error",


### PR DESCRIPTION
### Proposed Changes

Changes sveverity of the `no-inclusive-gateway` rule from error to warning.

Related to https://github.com/camunda/camunda-modeler/issues/5822.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
